### PR TITLE
Update to fix secret store index break

### DIFF
--- a/src/commands/serverCommand.ts
+++ b/src/commands/serverCommand.ts
@@ -170,7 +170,9 @@ export function addKdbConnection(): void {
                 ) {
                   authUsed = true;
                   ext.secretSettings.storeAuthData(
-                    `${hostname}:${port}`,
+                    alias !== undefined
+                      ? getHash(`${hostname}${port}${alias}`)
+                      : getHash(`${hostname}${port}`),
                     `${username}:${password}`
                   );
                 }
@@ -262,7 +264,7 @@ export async function connect(viewItem: KdbNode): Promise<void> {
   }
 
   // check for auth
-  const authCredentials = await ext.secretSettings.getAuthData(viewItem.label);
+  const authCredentials = await ext.secretSettings.getAuthData(viewItem.children[0]);
   const servers: Server | undefined = getServers();
   if (servers === undefined) {
     window.showErrorMessage('Server not found.');


### PR DESCRIPTION
This update fixes a break that happened as a result of changes to the server object persisted and stored in the extension settings and the secret store for setting and getting auth credentials for remote kdb instances.