### PR TITLE
Updates to fix existing q installation flow issue with manual path setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "KXDB vscode",
   "description": "Extension to help with Q and KXDB",
   "publisher": "kx",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "engines": {
     "vscode": "^1.66.0"
   },
@@ -78,6 +78,10 @@
           "type": "boolean",
           "description": "Hide visibility of the walkthrough at startup of extension"
         },
+        "kdb.hideInstallationNotification": {
+          "type": "boolean",
+          "description": "Hide notification for installation path, after first install"
+        },
         "kdb.qHomeDirectory": {
           "type": "string",
           "description": "QHOME directory for Q runtime"
@@ -127,21 +131,21 @@
       }
     ],
     "keybindings": [
-        {
-            "command": "kxdb.execute.selectedQuery",
-            "key": "ctrl+q",
-            "when": "editorLangId == q"
-        },
-        {
-            "command": "kxdb.execute.fileQuery",
-            "key": "ctrl+shift+q",
-            "when": "editorLangId == q"
-        },
-        {
-            "command": "kxdb.terminal.run",
-            "key": "ctrl+shift+r",
-            "when": "editorLangId == q"
-        }
+      {
+        "command": "kxdb.execute.selectedQuery",
+        "key": "ctrl+q",
+        "when": "editorLangId == q"
+      },
+      {
+        "command": "kxdb.execute.fileQuery",
+        "key": "ctrl+shift+q",
+        "when": "editorLangId == q"
+      },
+      {
+        "command": "kxdb.terminal.run",
+        "key": "ctrl+shift+r",
+        "when": "editorLangId == q"
+      }
     ],
     "snippets": [
       {

--- a/src/commands/installTools.ts
+++ b/src/commands/installTools.ts
@@ -1,9 +1,9 @@
-import extract from 'extract-zip';
-import { copy, ensureDir, existsSync, pathExists } from 'fs-extra';
-import fetch from 'node-fetch';
-import { writeFile } from 'node:fs/promises';
-import { env, exit } from 'node:process';
-import { join } from 'path';
+import extract from "extract-zip";
+import { copy, ensureDir, existsSync, pathExists } from "fs-extra";
+import fetch from "node-fetch";
+import { writeFile } from "node:fs/promises";
+import { env, exit } from "node:process";
+import { join } from "path";
 import {
   ConfigurationTarget,
   InputBoxOptions,
@@ -13,8 +13,8 @@ import {
   commands,
   window,
   workspace,
-} from 'vscode';
-import { ext } from '../extensionVariables';
+} from "vscode";
+import { ext } from "../extensionVariables";
 import {
   licenseAquire,
   licenseFileInput,
@@ -25,10 +25,13 @@ import {
   licenseTypePlaceholder,
   licenseTypes,
   licenseWorkflow,
-} from '../models/items/license';
-import { onboardingInput, onboardingWorkflow } from '../models/items/onboarding';
-import { Server } from '../models/server';
-import { KdbNode } from '../services/kdbTreeProvider';
+} from "../models/items/license";
+import {
+  onboardingInput,
+  onboardingWorkflow,
+} from "../models/items/onboarding";
+import { Server } from "../models/server";
+import { KdbNode } from "../services/kdbTreeProvider";
 import {
   addLocalConnectionContexts,
   addLocalConnectionStatus,
@@ -38,28 +41,30 @@ import {
   getOsFile,
   getServerName,
   getServers,
+  getWorkspaceFolder,
   removeLocalConnectionStatus,
   saveLocalProcessObj,
   updateServers,
-} from '../utils/core';
-import { executeCommand } from '../utils/cpUtils';
-import { openUrl } from '../utils/openUrl';
-import { Telemetry } from '../utils/telemetryClient';
-import { validateServerPort } from '../validators/kdbValidator';
-import { showWalkthrough } from './walkthroughCommand';
+} from "../utils/core";
+import { executeCommand } from "../utils/cpUtils";
+import { openUrl } from "../utils/openUrl";
+import { Telemetry } from "../utils/telemetryClient";
+import { validateServerPort } from "../validators/kdbValidator";
+import { showWalkthrough } from "./walkthroughCommand";
 
 export async function installTools(): Promise<void> {
   let file: Uri[] | undefined;
   let runtimeUrl: string;
 
-  await commands.executeCommand('notifications.clearAll');
-  await commands.executeCommand('welcome.goBack');
-  commands.executeCommand('setContext', 'kdb.showInstallWalkthrough', false);
+  await commands.executeCommand("notifications.clearAll");
+  await commands.executeCommand("welcome.goBack");
+  commands.executeCommand("setContext", "kdb.showInstallWalkthrough", false);
 
-  const licenseTypeResult: QuickPickItem | undefined = await window.showQuickPick(licenseItems, {
-    placeHolder: licensePlaceholder,
-    ignoreFocusOut: true,
-  });
+  const licenseTypeResult: QuickPickItem | undefined =
+    await window.showQuickPick(licenseItems, {
+      placeHolder: licensePlaceholder,
+      ignoreFocusOut: true,
+    });
 
   if (licenseTypeResult?.label === licenseAquire) {
     let licenseCancel;
@@ -70,7 +75,7 @@ export async function installTools(): Promise<void> {
         licenseWorkflow.option1,
         licenseWorkflow.option2
       )
-      .then(async res => {
+      .then(async (res) => {
         if (res === licenseWorkflow.option2) {
           licenseCancel = true;
         }
@@ -78,10 +83,13 @@ export async function installTools(): Promise<void> {
     if (licenseCancel) return;
   }
 
-  const licenseResult: QuickPickItem | undefined = await window.showQuickPick(licenseTypes, {
-    placeHolder: licenseTypePlaceholder,
-    ignoreFocusOut: true,
-  });
+  const licenseResult: QuickPickItem | undefined = await window.showQuickPick(
+    licenseTypes,
+    {
+      placeHolder: licenseTypePlaceholder,
+      ignoreFocusOut: true,
+    }
+  );
 
   if (licenseResult === undefined) {
     return;
@@ -92,7 +100,7 @@ export async function installTools(): Promise<void> {
       ignoreFocusOut: true,
     };
 
-    await window.showInputBox(licenseInput).then(async encodedLicense => {
+    await window.showInputBox(licenseInput).then(async (encodedLicense) => {
       if (encodedLicense !== undefined) {
         file = [await convertBase64License(encodedLicense)];
       }
@@ -114,34 +122,44 @@ export async function installTools(): Promise<void> {
     .withProgress(
       {
         location: ProgressLocation.Notification,
-        title: 'Installation of Q',
+        title: "Installation of Q",
         cancellable: true,
       },
       async (progress, token) => {
         token.onCancellationRequested(() => {
-          ext.outputChannel.appendLine('User cancelled the installation.');
+          ext.outputChannel.appendLine("User cancelled the installation.");
         });
 
         progress.report({ increment: 0 });
 
         // download the binaries
-        progress.report({ increment: 20, message: 'Getting the binaries...' });
+        progress.report({ increment: 20, message: "Getting the binaries..." });
         const osFile = getOsFile();
         if (osFile === undefined) {
           ext.outputChannel.appendLine(
-            'Unsupported operating system, unable to download binaries for this.'
+            "Unsupported operating system, unable to download binaries for this."
           );
           Telemetry.sendException(
-            new Error('Unsupported operating system, unable to download binaries')
+            new Error(
+              "Unsupported operating system, unable to download binaries"
+            )
           );
         } else {
           const gpath = join(ext.context.globalStorageUri.fsPath, osFile);
           if (!existsSync(gpath)) {
-            const response = await fetch(`${ext.kdbDownloadPrefixUrl}${osFile}`);
+            const response = await fetch(
+              `${ext.kdbDownloadPrefixUrl}${osFile}`
+            );
             if (response.status > 200) {
-              Telemetry.sendException(new Error('Invalid or unavailable download url.'));
-              ext.outputChannel.appendLine(`Invalid or unavailable download url: ${runtimeUrl}`);
-              window.showErrorMessage(`Invalid or unavailable download url: ${runtimeUrl}`);
+              Telemetry.sendException(
+                new Error("Invalid or unavailable download url.")
+              );
+              ext.outputChannel.appendLine(
+                `Invalid or unavailable download url: ${runtimeUrl}`
+              );
+              window.showErrorMessage(
+                `Invalid or unavailable download url: ${runtimeUrl}`
+              );
               exit(1);
             }
             await ensureDir(ext.context.globalStorageUri.fsPath);
@@ -151,40 +169,50 @@ export async function installTools(): Promise<void> {
         }
 
         // move the license file
-        progress.report({ increment: 30, message: 'Moving license file...' });
+        progress.report({ increment: 30, message: "Moving license file..." });
         await delay(500);
         await ensureDir(ext.context.globalStorageUri.fsPath);
-        await copy(file![0].fsPath, join(ext.context.globalStorageUri.fsPath, ext.kdbLicName));
+        await copy(
+          file![0].fsPath,
+          join(ext.context.globalStorageUri.fsPath, ext.kdbLicName)
+        );
 
         // add the env var for the process
-        progress.report({ increment: 60, message: 'Setting up environment...' });
+        progress.report({
+          increment: 60,
+          message: "Setting up environment...",
+        });
         await delay(500);
         env.QHOME = ext.context.globalStorageUri.fsPath;
 
         // persist the QHOME to global settings
         await workspace
           .getConfiguration()
-          .update('kdb.qHomeDirectory', env.QHOME, ConfigurationTarget.Global);
+          .update("kdb.qHomeDirectory", env.QHOME, ConfigurationTarget.Global);
 
         // update walkthrough
-        const QHOME = workspace.getConfiguration().get<string>('kdb.qHomeDirectory');
+        const QHOME = workspace
+          .getConfiguration()
+          .get<string>("kdb.qHomeDirectory");
         if (QHOME) {
           env.QHOME = QHOME;
           if (!pathExists(env.QHOME)) {
-            ext.outputChannel.appendLine('QHOME path stored is empty');
+            ext.outputChannel.appendLine("QHOME path stored is empty");
           }
           await writeFile(
-            join(__dirname, 'qinstall.md'),
+            join(__dirname, "qinstall.md"),
             `# Q runtime installed location: \n### ${QHOME}`
           );
-          ext.outputChannel.appendLine(`Installation of Q found here: ${QHOME}`);
+          ext.outputChannel.appendLine(
+            `Installation of Q found here: ${QHOME}`
+          );
         }
 
         // hide walkthrough if requested
         if (await showWalkthrough()) {
           commands.executeCommand(
-            'workbench.action.openWalkthrough',
-            'kx.kxdb-vscode#qinstallation',
+            "workbench.action.openWalkthrough",
+            "kx.kxdb-vscode#qinstallation",
             false
           );
         }
@@ -197,31 +225,37 @@ export async function installTools(): Promise<void> {
           onboardingWorkflow.option1,
           onboardingWorkflow.option2
         )
-        .then(async startResult => {
+        .then(async (startResult) => {
           if (startResult === onboardingWorkflow.option1) {
             const portInput: InputBoxOptions = {
               prompt: onboardingInput.prompt,
               placeHolder: onboardingInput.placeholder,
               ignoreFocusOut: true,
-              validateInput: (value: string | undefined) => validateServerPort(value),
+              validateInput: (value: string | undefined) =>
+                validateServerPort(value),
             };
-            window.showInputBox(portInput).then(async port => {
+            window.showInputBox(portInput).then(async (port) => {
               if (port) {
                 let servers: Server | undefined = getServers();
-                if (servers != undefined && servers[getHash(`localhost:${port}`)]) {
+                if (
+                  servers != undefined &&
+                  servers[getHash(`localhost:${port}`)]
+                ) {
                   Telemetry.sendEvent(
                     `Server localhost:${port} already exists in configuration store.`
                   );
-                  await window.showErrorMessage(`Server localhost:${port} already exists.`);
+                  await window.showErrorMessage(
+                    `Server localhost:${port} already exists.`
+                  );
                 } else {
                   const key = getHash(`localhost${port}local`);
                   if (servers === undefined) {
                     servers = {
                       key: {
                         auth: false,
-                        serverName: 'localhost',
+                        serverName: "localhost",
                         serverPort: port,
-                        serverAlias: 'local',
+                        serverAlias: "local",
                         managed: true,
                       },
                     };
@@ -229,12 +263,14 @@ export async function installTools(): Promise<void> {
                   } else {
                     servers[key] = {
                       auth: false,
-                      serverName: 'localhost',
+                      serverName: "localhost",
                       serverPort: port,
-                      serverAlias: 'local',
+                      serverAlias: "local",
                       managed: true,
                     };
-                    await addLocalConnectionContexts(getServerName(servers[key]));
+                    await addLocalConnectionContexts(
+                      getServerName(servers[key])
+                    );
                   }
                   await updateServers(servers);
                   const newServers = getServers();
@@ -259,27 +295,32 @@ export async function startLocalProcessByServerName(
   index: string,
   port: number
 ): Promise<void> {
-  const workingDirectory = join(
-    ext.context.globalStorageUri.fsPath,
-    process.platform == 'win32' ? 'w64' : 'm64'
+  const workingDirectory = await getWorkspaceFolder(
+    workspace.getConfiguration().get<string>("kdb.qHomeDirectory")!
   );
 
   await addLocalConnectionStatus(serverName);
-  await executeCommand(workingDirectory, 'q', saveLocalProcessObj, '-p', port.toString(), index);
+  await executeCommand(
+    workingDirectory,
+    "q",
+    saveLocalProcessObj,
+    "-p",
+    port.toString(),
+    index
+  );
 }
 
 export async function startLocalProcess(viewItem: KdbNode): Promise<void> {
-  const workingDirectory = join(
-    ext.context.globalStorageUri.fsPath,
-    process.platform == 'win32' ? 'w64' : 'm64'
+  const workingDirectory = await getWorkspaceFolder(
+    workspace.getConfiguration().get<string>("kdb.qHomeDirectory")!
   );
 
   await addLocalConnectionStatus(`${getServerName(viewItem.details)}`);
   await executeCommand(
     workingDirectory,
-    'q',
+    "q",
     saveLocalProcessObj,
-    '-p',
+    "-p",
     viewItem.details.serverPort.toString(),
     viewItem.children[0]
   );
@@ -287,17 +328,21 @@ export async function startLocalProcess(viewItem: KdbNode): Promise<void> {
 
 export async function stopLocalProcess(viewItem: KdbNode): Promise<void> {
   ext.localProcessObjects[viewItem.children[0]].kill();
-  window.showInformationMessage('Q process stopped successfully!');
+  window.showInformationMessage("Q process stopped successfully!");
   ext.outputChannel.appendLine(
-    `Child process id ${ext.localProcessObjects[viewItem.children[0]].pid!} removed in cache.`
+    `Child process id ${ext.localProcessObjects[viewItem.children[0]]
+      .pid!} removed in cache.`
   );
   await removeLocalConnectionStatus(`${getServerName(viewItem.details)}`);
 }
 
-export async function stopLocalProcessByServerName(serverName: string): Promise<void> {
+export async function stopLocalProcessByServerName(
+  serverName: string
+): Promise<void> {
   ext.localProcessObjects[serverName].kill();
-  window.showInformationMessage('Q process stopped successfully!');
+  window.showInformationMessage("Q process stopped successfully!");
   ext.outputChannel.appendLine(
-    `Child process id ${ext.localProcessObjects[serverName].pid!} removed in cache.`
+    `Child process id ${ext.localProcessObjects[serverName]
+      .pid!} removed in cache.`
   );
 }

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -1,108 +1,196 @@
-import { ChildProcess } from 'child_process';
-import { createHash } from 'crypto';
-import { pathExists } from 'fs-extra';
-import { writeFile } from 'fs/promises';
-import { env } from 'node:process';
-import { tmpdir } from 'os';
-import { join } from 'path';
-import { ConfigurationTarget, Uri, commands, window, workspace } from 'vscode';
-import { installTools } from '../commands/installTools';
-import { ext } from '../extensionVariables';
-import { QueryResult } from '../models/queryResult';
-import { Server, ServerDetails } from '../models/server';
+import { ChildProcess } from "child_process";
+import { createHash } from "crypto";
+import { pathExists } from "fs-extra";
+import { writeFile } from "fs/promises";
+import { env } from "node:process";
+import { tmpdir } from "os";
+import { join } from "path";
+import { ConfigurationTarget, Uri, commands, window, workspace } from "vscode";
+import { installTools } from "../commands/installTools";
+import { ext } from "../extensionVariables";
+import { QueryResult } from "../models/queryResult";
+import { Server, ServerDetails } from "../models/server";
 
 export function getHash(input: string): string {
-  return createHash('sha256').update(input).digest('base64');
+  return createHash("sha256").update(input).digest("base64");
 }
 
 export function initializeLocalServers(servers: Server): void {
-  Object.keys(servers!).forEach(server => {
+  Object.keys(servers!).forEach((server) => {
     if (servers![server].managed === true) {
       addLocalConnectionContexts(getServerName(servers![server]));
     }
   });
 }
 
-export async function addLocalConnectionStatus(serverName: string): Promise<void> {
+export async function addLocalConnectionStatus(
+  serverName: string
+): Promise<void> {
   ext.localConnectionStatus.push(serverName);
-  await commands.executeCommand('setContext', 'kdb.running', ext.localConnectionStatus);
+  await commands.executeCommand(
+    "setContext",
+    "kdb.running",
+    ext.localConnectionStatus
+  );
 }
 
-export async function removeLocalConnectionStatus(serverName: string): Promise<void> {
-  const result = ext.localConnectionStatus.filter(connection => connection !== serverName);
+export async function removeLocalConnectionStatus(
+  serverName: string
+): Promise<void> {
+  const result = ext.localConnectionStatus.filter(
+    (connection) => connection !== serverName
+  );
   ext.localConnectionStatus = result;
-  await commands.executeCommand('setContext', 'kdb.running', ext.localConnectionStatus);
+  await commands.executeCommand(
+    "setContext",
+    "kdb.running",
+    ext.localConnectionStatus
+  );
 }
 
-export async function addLocalConnectionContexts(serverName: string): Promise<void> {
+export async function addLocalConnectionContexts(
+  serverName: string
+): Promise<void> {
   ext.localConnectionContexts.push(serverName);
-  await commands.executeCommand('setContext', 'kdb.local', ext.localConnectionContexts);
+  await commands.executeCommand(
+    "setContext",
+    "kdb.local",
+    ext.localConnectionContexts
+  );
 }
 
-export async function removeLocalConnectionContext(serverName: string): Promise<void> {
-  const result = ext.localConnectionContexts.filter(connection => connection !== serverName);
+export async function removeLocalConnectionContext(
+  serverName: string
+): Promise<void> {
+  const result = ext.localConnectionContexts.filter(
+    (connection) => connection !== serverName
+  );
   ext.localConnectionContexts = result;
-  await commands.executeCommand('setContext', 'kdb.local', ext.localConnectionContexts);
+  await commands.executeCommand(
+    "setContext",
+    "kdb.local",
+    ext.localConnectionContexts
+  );
 }
 
-export function saveLocalProcessObj(childProcess: ChildProcess, args: string[]): void {
-  window.showInformationMessage('Q process started successfully!');
-  ext.outputChannel.appendLine(`Child process id ${childProcess.pid!} saved in cache.`);
+export function saveLocalProcessObj(
+  childProcess: ChildProcess,
+  args: string[]
+): void {
+  window.showInformationMessage("Q process started successfully!");
+  ext.outputChannel.appendLine(
+    `Child process id ${childProcess.pid!} saved in cache.`
+  );
   ext.localProcessObjects[args[2]] = childProcess;
 }
 
 export function getOsFile(): string | undefined {
-  if (process.platform === 'win32') {
-    return 'w64.zip';
-  } else if (process.platform === 'darwin') {
-    return 'm64.zip';
-  } else if (process.platform === 'linux') {
-    return 'l64.zip';
+  if (process.platform === "win32") {
+    return "w64.zip";
+  } else if (process.platform === "darwin") {
+    return "m64.zip";
+  } else if (process.platform === "linux") {
+    return "l64.zip";
   } else {
     return undefined;
   }
 }
 
+export function getPlatformFolder(platform: string): string | undefined {
+  if (platform === "win32") {
+    return "w64";
+  } else if (platform === "darwin") {
+    return "m64";
+  } else if (platform === "linux") {
+    return "l64";
+  }
+  return undefined;
+}
+
+export async function getWorkspaceFolder(
+  corePath: string
+): Promise<string | undefined> {
+  if (await pathExists(join(corePath, "q"))) {
+    return corePath;
+  } else if (
+    await pathExists(join(corePath, getPlatformFolder(process.platform)!))
+  ) {
+    return join(corePath, getPlatformFolder(process.platform)!);
+  }
+  return undefined;
+}
+
 export function getServers(): Server | undefined {
-  return workspace.getConfiguration().get('kdb.servers');
+  return workspace.getConfiguration().get("kdb.servers");
 }
 
 export async function updateServers(servers: Server): Promise<void> {
-  await workspace.getConfiguration().update('kdb.servers', servers, ConfigurationTarget.Global);
+  await workspace
+    .getConfiguration()
+    .update("kdb.servers", servers, ConfigurationTarget.Global);
 }
 
 export function getServerName(server: ServerDetails): string {
-  return server.serverAlias != ''
+  return server.serverAlias != ""
     ? `${server.serverName}:${server.serverPort} [${server.serverAlias}]`
     : `${server.serverName}:${server.serverPort}`;
 }
 
 export function delay(ms: number) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export async function checkLocalInstall(): Promise<void> {
-  const QHOME = workspace.getConfiguration().get<string>('kdb.qHomeDirectory');
-  if (QHOME) {
-    env.QHOME = QHOME;
-    if (!pathExists(env.QHOME)) {
-      ext.outputChannel.appendLine('QHOME path stored is empty');
+  const QHOME = workspace.getConfiguration().get<string>("kdb.qHomeDirectory");
+  if (QHOME || env.QHOME) {
+    env.QHOME = QHOME || env.QHOME;
+    if (!pathExists(env.QHOME!)) {
+      ext.outputChannel.appendLine("QHOME path stored is empty");
     }
     await writeFile(
-      join(__dirname, 'qinstall.md'),
-      `# Q runtime installed location: \n### ${QHOME}`
+      join(__dirname, "qinstall.md"),
+      `# Q runtime installed location: \n### ${env.QHOME}`
     );
-    ext.outputChannel.appendLine(`Installation of Q found here: ${QHOME}`);
+
+    // persist the QHOME to global settings
+    await workspace
+      .getConfiguration()
+      .update("kdb.qHomeDirectory", env.QHOME, ConfigurationTarget.Global);
+
+    ext.outputChannel.appendLine(`Installation of Q found here: ${env.QHOME}`);
+
+    const hideNotification = await workspace
+      .getConfiguration()
+      .get<boolean>("kdb.hideInstallationNotification");
+    if (!hideNotification) {
+      window.showInformationMessage(
+        `Installation of Q found here: ${env.QHOME}`
+      );
+    }
+
+    // persist the notification seen option
+    await workspace
+      .getConfiguration()
+      .update(
+        "kdb.hideInstallationNotification",
+        true,
+        ConfigurationTarget.Global
+      );
+
     return;
   }
 
   // set custom context that QHOME is not setup to control walkthrough visibility
-  commands.executeCommand('setContext', 'kdb.showInstallWalkthrough', true);
+  commands.executeCommand("setContext", "kdb.showInstallWalkthrough", true);
 
   window
-    .showInformationMessage('Local Q installation not found!', 'Install new instance', 'Cancel')
-    .then(async installResult => {
-      if (installResult === 'Install new instance') {
+    .showInformationMessage(
+      "Local Q installation not found!",
+      "Install new instance",
+      "Cancel"
+    )
+    .then(async (installResult) => {
+      if (installResult === "Install new instance") {
         await installTools();
       }
     });
@@ -112,9 +200,9 @@ export async function convertBase64License(
   encodedLicense: string,
   tempDir: string = tmpdir()
 ): Promise<Uri> {
-  const decodedLicense = Buffer.from(encodedLicense, 'base64');
-  await writeFile(join(tempDir, 'kc.lic'), decodedLicense);
-  return Uri.parse(join(tmpdir(), 'kc.lic'));
+  const decodedLicense = Buffer.from(encodedLicense, "base64");
+  await writeFile(join(tempDir, "kc.lic"), decodedLicense);
+  return Uri.parse(join(tmpdir(), "kc.lic"));
 }
 
 export function isTable(result: QueryResult): boolean {
@@ -132,10 +220,10 @@ export function formatTable(headers_: any, rows_: any, opts: any) {
 
   const data = new Array(rows_.length);
   for (let i = 0; i < rows_.lenth; ++i) {
-    data[i] = typeof rows_[i] === 'object' ? Object.values(rows_[i]) : rows_[i];
+    data[i] = typeof rows_[i] === "object" ? Object.values(rows_[i]) : rows_[i];
   }
 
-  const hsep = opts.hsep === undefined ? ' ' : opts.hsep;
+  const hsep = opts.hsep === undefined ? " " : opts.hsep;
   const align = opts.align || [];
   const keys = opts.keys || [];
   const stringLength =
@@ -175,13 +263,13 @@ export function formatTable(headers_: any, rows_: any, opts: any) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return map(row, function (c_: any, ix: any) {
       const c = String(c_);
-      if (align[ix] === '.') {
+      if (align[ix] === ".") {
         const [left, right] = dotoffsets(c);
         const test = /\./.test(c);
         const [maxLeft, maxRight] = dotsizes[ix];
         const leftSize = maxLeft - left;
         const rightSize = (maxRight === 0 || test ? 0 : 1) + maxRight - right;
-        return ' '.repeat(leftSize) + c + ' '.repeat(rightSize);
+        return " ".repeat(leftSize) + c + " ".repeat(rightSize);
       } else {
         return c;
       }
@@ -211,13 +299,17 @@ export function formatTable(headers_: any, rows_: any, opts: any) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return map(row, function (c: any, ix: any) {
       const n = sizes[ix] - stringLength(c) || 0;
-      const s = Array(Math.max(n + 1, 1)).join(' ');
-      if (align[ix] === 'r' /* || align[ix] === '.'*/) {
+      const s = Array(Math.max(n + 1, 1)).join(" ");
+      if (align[ix] === "r" /* || align[ix] === '.'*/) {
         return s + c;
       }
 
-      if (align[ix] === 'c') {
-        return Array(Math.ceil(n / 2 + 1)).join(' ') + c + Array(Math.floor(n / 2 + 1)).join(' ');
+      if (align[ix] === "c") {
+        return (
+          Array(Math.ceil(n / 2 + 1)).join(" ") +
+          c +
+          Array(Math.floor(n / 2 + 1)).join(" ")
+        );
       }
 
       return c + s;
@@ -226,7 +318,7 @@ export function formatTable(headers_: any, rows_: any, opts: any) {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const headers = map(headers_, function (c: any, ix: any) {
-    return c + ' '.repeat(Math.max(0, sizes[ix] - c.length));
+    return c + " ".repeat(Math.max(0, sizes[ix] - c.length));
   });
 
   let columnSeparatorIndex = 0;
@@ -235,7 +327,7 @@ export function formatTable(headers_: any, rows_: any, opts: any) {
   }
 
   const header = headers.join(hsep);
-  const separator = '-'.repeat(header.length);
+  const separator = "-".repeat(header.length);
 
   result.unshift(separator);
   result.unshift(header);
@@ -245,10 +337,10 @@ export function formatTable(headers_: any, rows_: any, opts: any) {
     const insertAt = (str: any, sub: any, pos: any) =>
       `${str.slice(0, pos)}${sub}${str.slice(pos)}`;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    result = result.map((x: any) => insertAt(x, '|', columnSeparatorIndex + 1));
+    result = result.map((x: any) => insertAt(x, "|", columnSeparatorIndex + 1));
   }
 
-  return result.join('\n');
+  return result.join("\n");
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This PR is to address the issue raised that if users have existing Q installation, the QHOME is not respected correctly by the extension.  

* With the managed installation we can trust the install, but with a user installation, we have to assume they have this installed correctly and can fix it if they don't.
* With managed installation we can allow the user to add additional _local_ connections and get the feature to stop/start them.  With external installed Q this was not the case.

This PR fixes these with the following assumptions:

* We had to add a big of additional logic to the extension because QHOME could be one level up from where the actual binary is, which was the case with the Mac I tested with, Windows seemed fine even though it was the same. 
* If the user has another setup for Q, where the binary is not directly in the QHOME or one level down (or customized folder names), then exceptions will occur.