### PR TITLE
Update to fix issue where views are shown as variables and not in view category for default namespace

### DIFF
--- a/src/services/kdbTreeProvider.ts
+++ b/src/services/kdbTreeProvider.ts
@@ -174,12 +174,12 @@ export class KdbTreeProvider implements TreeDataProvider<TreeItem> {
       }
     } else if (serverType.label === ext.qObjectCategories[4]) {
       // views
-      const views = await loadViews(serverType.contextValue ?? "");
+      const views = await loadViews();
       const result = views.map(
         (x) =>
           new QServerNode(
             [],
-            `${ns}${ns === "." ? "" : "."}${x.name}`,
+            `${ns}${ns === "." ? "" : "."}${x}`,
             "",
             TreeItemCollapsibleState.None
           )


### PR DESCRIPTION
This update fixes 2 issues:

* The tree currently displays views as well as variables under the variables node in the tree.  This fix will filter out views from the variables.
* The tree currently does not display views under the views node in the tree.  This fix will allow views to be shown here.