### PR TITLE
Fixed bug where namespaces without a  prefix would have duplicate items and incorrect contexts

### DIFF
--- a/src/q/list_mem.q
+++ b/src/q/list_mem.q
@@ -40,7 +40,9 @@
         ([] id: ids; pid: pids; name: names; fname: fnames; typeNum: typs; namespace: ns; context: contexts; isNs: isNs)
         };
 
-    getContext: {[ns] $[ns in ``.; `; ` sv 2#` vs ns] };
+    getContext: {[ns]
+        $[ns in ``.; `; $[1 < count p:` vs ns; ` sv 2#` vs ns; ns]]
+        };
 
     prefix: {$[`. = x; y; ` sv/: x ,/: y]};
 
@@ -57,8 +59,8 @@
         f: {[buildRows; getContext; getNs; prefix; exclude; x]
             ns: first x 0;
             lastId: last exec id from x 1;
-            // Get all items in the namespace
-            fnames: prefix[ns`fname] n: except[;`] key ns`fname;
+            // Get all items in the namespace, excluding namespaces that we are already going to enumerate
+            fnames: fns where not (fns: prefix[ns`fname] n: except[;`] key ns`fname) in x[0]`fname;
             // Isolate namespaces specifically and build their entries
             nmsnum: count nms: $[`. ~ ns`fname; ::; exclude] allnms: getNs ns`fname;
             context: getContext ns`fname;

--- a/test/q/list_mem.quke
+++ b/test/q/list_mem.quke
@@ -78,3 +78,18 @@ feature list_mem
                 );
             .qu.compare[.ignore.r] .ignore.e
 
+    should handle edge cases
+        expect namespaces that aren't prefixed with `.` to be handled correctly
+            value "noDot.table: ([] til 100)";
+            .ignore.r: value .ignore.fnStr, .ignore.blacklist;
+            .ignore.e: ([]
+                id: 0 1 2 4 5 6 7 3i;
+                pid: (3#0Ni), (3#2i), 5 1i;
+                name: `.`noDot`.test`namespace`otherNs`badns`var`table;
+                fname: `.`noDot`.test`.test.namespace`.test.otherNs`.test.badns`.test.otherNs.var`noDot.table;
+                typeNum: (6# 99h), 7 98h;
+                namespace: `.`.`.`.test`.test`.test`.test.otherNs`noDot;
+                context: (3#`),(4#`.test),`noDot;
+                isNs: 11111100b
+                );
+            .qu.compare[.ignore.r] .ignore.e


### PR DESCRIPTION
Namespaces without a `.` prefix no longer duplicate their entries:

<img width="472" alt="image" src="https://github.com/KxSystems/kx-vscode/assets/126584021/ce27a97c-bbe6-441b-b345-013afbf56a93">

Added a test case and all tests passing:

<img width="786" alt="image" src="https://github.com/KxSystems/kx-vscode/assets/126584021/b1515144-afec-4222-a201-edd6a8bb47e8">
