### PR TITLE
Update to fix a few tree related issues

### DIFF
--- a/resources/list_mem.q
+++ b/resources/list_mem.q
@@ -40,7 +40,9 @@
         ([] id: ids; pid: pids; name: names; fname: fnames; typeNum: typs; namespace: ns; context: contexts; isNs: isNs)
         };
 
-    getContext: {[ns] $[ns in ``.; `; ` sv 2#` vs ns] };
+    getContext: {[ns]
+        $[ns in ``.; `; $[1 < count p:` vs ns; ` sv 2#` vs ns; ns]]
+        };
 
     prefix: {$[`. = x; y; ` sv/: x ,/: y]};
 
@@ -57,8 +59,8 @@
         f: {[buildRows; getContext; getNs; prefix; exclude; x]
             ns: first x 0;
             lastId: last exec id from x 1;
-            // Get all items in the namespace
-            fnames: prefix[ns`fname] n: except[;`] key ns`fname;
+            // Get all items in the namespace, excluding namespaces that we are already going to enumerate
+            fnames: fns where not (fns: prefix[ns`fname] n: except[;`] key ns`fname) in x[0]`fname;
             // Isolate namespaces specifically and build their entries
             nmsnum: count nms: $[`. ~ ns`fname; ::; exclude] allnms: getNs ns`fname;
             context: getContext ns`fname;

--- a/src/models/serverObject.ts
+++ b/src/models/serverObject.ts
@@ -84,7 +84,7 @@ export async function loadViews(): Promise<string[]> {
   const rawViews = await ext.connection?.executeQuery("views`");
   const rawViewArray = rawViews?.replace("\r\n", "").split("`");
   const views = rawViewArray?.filter((item) => {
-    return item !== "s#" && item !== "";
+    return item !== "s#" && item !== "" && item !== ",";
   });
   return views ?? new Array<string>();
 }

--- a/src/services/kdbTreeProvider.ts
+++ b/src/services/kdbTreeProvider.ts
@@ -17,6 +17,7 @@ import {
   loadVariables,
   loadViews,
 } from "../models/serverObject";
+import { getServerName } from "../utils/core";
 
 export class KdbTreeProvider implements TreeDataProvider<TreeItem> {
   private _onDidChangeTreeData: EventEmitter<KdbNode | undefined | void> =
@@ -115,7 +116,7 @@ export class KdbTreeProvider implements TreeDataProvider<TreeItem> {
         (x) =>
           new QServerNode(
             [],
-            `${ns}${ns === "." ? "" : "."}${x.name}`,
+            `${ns === "." ? "" : ns + "."}${x.name}`,
             "",
             TreeItemCollapsibleState.None
           )
@@ -132,7 +133,7 @@ export class KdbTreeProvider implements TreeDataProvider<TreeItem> {
         (x) =>
           new QServerNode(
             [],
-            `${ns}${ns === "." ? "" : "."}${x.name}`,
+            `${ns === "." ? "" : ns + "."}${x.name}`,
             "",
             TreeItemCollapsibleState.None
           )
@@ -149,7 +150,7 @@ export class KdbTreeProvider implements TreeDataProvider<TreeItem> {
         (x) =>
           new QServerNode(
             [],
-            `${ns}${ns === "." ? "" : "."}${x.name}`,
+            `${ns === "." ? "" : ns + "."}${x.name}`,
             "",
             TreeItemCollapsibleState.None
           )
@@ -166,7 +167,7 @@ export class KdbTreeProvider implements TreeDataProvider<TreeItem> {
         (x) =>
           new QServerNode(
             [],
-            `${ns}${ns === "." ? "" : "."}${x.name}`,
+            `${ns === "." ? "" : ns + "."}${x.name}`,
             "",
             TreeItemCollapsibleState.None
           )
@@ -183,7 +184,7 @@ export class KdbTreeProvider implements TreeDataProvider<TreeItem> {
         (x) =>
           new QServerNode(
             [],
-            `${ns}${ns === "." ? "" : "."}${x}`,
+            `${ns === "." ? "" : "."}${x}`,
             "",
             TreeItemCollapsibleState.None
           )
@@ -205,7 +206,9 @@ export class KdbTreeProvider implements TreeDataProvider<TreeItem> {
           x.split(":"),
           `${servers[x].serverName}:${servers[x].serverPort}`,
           servers[x],
-          TreeItemCollapsibleState.Collapsed
+          ext.connectionNode?.label === getServerName(servers[x])
+            ? TreeItemCollapsibleState.Collapsed
+            : TreeItemCollapsibleState.None
         )
     );
   }


### PR DESCRIPTION
This update is to fix a few items identified:

* Update that will display objects in the default namespace with no prepended "."
* Update that will only allow expanding the instance/node if a connection is active
* Update will filter "," namespace from views retrieval