### PR TITLE
Update to add session_state to token output object

### DIFF
--- a/src/services/kdbInsights/codeFlowLogin.ts
+++ b/src/services/kdbInsights/codeFlowLogin.ts
@@ -31,6 +31,7 @@ export interface IToken {
   accessToken: string;
   accessTokenExpirationDate: Date;
   refreshToken: string;
+  session: string;
 }
 
 const defaultTimeout = 5 * 60 * 1000; // 5 min
@@ -126,6 +127,7 @@ async function tokenRequest(insightsUrl: string, params: any): Promise<IToken> {
     accessToken: result.access_token,
     accessTokenExpirationDate: expirationDate,
     refreshToken: result.refresh_token,
+    session: result.session_state,
   };
 }
 


### PR DESCRIPTION
This update will add the session state key to  the output object that is created for getToken requests.