### PR TITLE
Update to fix connection status on insights and token refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
       },
       {
         "command": "kdb.disconnect",
-        "title": "Disconnect kdb server"
+        "title": "Disconnect"
       },
       {
         "command": "kdb.dataSource.addDataSource",
@@ -410,7 +410,7 @@
         },
         {
           "command": "kdb.disconnect",
-          "when": "view == kdb-servers && viewItem in kdb.connected && viewItem in kdb.rootNodes",
+          "when": "view == kdb-servers && viewItem in kdb.connected && (viewItem in kdb.rootNodes || viewItem in kdb.insightsNodes)",
           "group": "connection"
         },
         {

--- a/src/commands/serverCommand.ts
+++ b/src/commands/serverCommand.ts
@@ -47,7 +47,11 @@ import { queryConstants } from "../models/queryResult";
 import { ScratchpadResult } from "../models/scratchpadResult";
 import { Server } from "../models/server";
 import { ServerObject } from "../models/serverObject";
-import { signIn } from "../services/kdbInsights/codeFlowLogin";
+import {
+  IToken,
+  refreshToken,
+  signIn,
+} from "../services/kdbInsights/codeFlowLogin";
 import { InsightsNode, KdbNode } from "../services/kdbTreeProvider";
 import {
   addLocalConnectionContexts,
@@ -308,12 +312,38 @@ export async function removeConnection(viewItem: KdbNode): Promise<void> {
 
 export async function connectInsights(viewItem: InsightsNode): Promise<void> {
   commands.executeCommand("kdb-results.focus");
-  const token = await signIn(viewItem.details.server);
-  ext.context.secrets.store(viewItem.details.alias, JSON.stringify(token));
+
+  let token: IToken | undefined;
+  const existingToken = await ext.context.secrets.get(viewItem.details.alias);
+  if (existingToken !== undefined) {
+    const storedToken: IToken = JSON.parse(existingToken);
+    if (new Date(storedToken.accessTokenExpirationDate) < new Date()) {
+      token = await refreshToken(
+        viewItem.details.server,
+        storedToken.refreshToken
+      );
+      if (token === undefined) {
+        token = await signIn(viewItem.details.server);
+        ext.context.secrets.store(
+          viewItem.details.alias,
+          JSON.stringify(token)
+        );
+      }
+    } else {
+      token = storedToken;
+    }
+  } else {
+    token = await signIn(viewItem.details.server);
+    ext.context.secrets.store(viewItem.details.alias, JSON.stringify(token));
+  }
 
   ext.outputChannel.appendLine(
     `Connection established successfully to: ${viewItem.details.server}`
   );
+
+  commands.executeCommand("setContext", "kdb.connected", [
+    viewItem.label + " (connected)",
+  ]);
 
   ext.connectionNode = viewItem;
   ext.serverProvider.reload();


### PR DESCRIPTION
This update is to fix:

* Connection status for insights does not filter out connect after connected (meaning you could try to connect after already connected)
* Refresh token not used for expired tokens