### PR TITLE
Update to revert to official node-q package, from the temp fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@types/klaw": "^3.0.3",
         "@types/picomatch": "^2.3.0",
         "@vscode/webview-ui-toolkit": "^1.2.2",
-        "@windozer/node-q": "^2.6.0",
         "azure-arm-resource": "^7.4.0",
         "csv-parser": "^3.0.0",
         "esbuild-plugin-copy": "^2.1.1",
@@ -28,6 +27,7 @@
         "fuse.js": "^6.6.2",
         "klaw": "^4.1.0",
         "node-fetch": "^2.6.6",
+        "node-q": "^2.6.1",
         "open": "^6.4.0",
         "picomatch": "^2.3.1",
         "request-promise": "^4.2.6",
@@ -923,19 +923,6 @@
       },
       "peerDependencies": {
         "react": ">=16.9.0"
-      }
-    },
-    "node_modules/@windozer/node-q": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@windozer/node-q/-/node-q-2.6.0.tgz",
-      "integrity": "sha512-8n82U2jdIarKgAa9iO8aPYdp5NRAnKBXOZQMkqOZNX8They8zViYsHTQkkjege855nY4s7sn+CUhs8JRTqxvIg==",
-      "dependencies": {
-        "buffer-indexof-polyfill": "1.0.1",
-        "long": "3.0.3",
-        "node-uuid": "1.4.7"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -3624,6 +3611,19 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-q": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-q/-/node-q-2.6.1.tgz",
+      "integrity": "sha512-OH8mx8R9jSjkMNkMUWrwUFiR/QEmfnqSYp61VxfTmSicvfz5UqufuY3Sh0l6o6hN10xeLKViWWngUs9QNYfstA==",
+      "dependencies": {
+        "buffer-indexof-polyfill": "1.0.1",
+        "long": "3.0.3",
+        "node-uuid": "1.4.7"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/node-uuid": {

--- a/package.json
+++ b/package.json
@@ -544,7 +544,7 @@
     "fuse.js": "^6.6.2",
     "klaw": "^4.1.0",
     "node-fetch": "^2.6.6",
-    "@windozer/node-q": "^2.6.0",
+    "node-q": "^2.6.1",
     "open": "^6.4.0",
     "picomatch": "^2.3.1",
     "request-promise": "^4.2.6",

--- a/src/models/connection.ts
+++ b/src/models/connection.ts
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-import * as nodeq from "@windozer/node-q";
+import * as nodeq from "node-q";
 import { commands, window } from "vscode";
 import { ext } from "../extensionVariables";
 import { delay } from "../utils/core";


### PR DESCRIPTION
This update is to revert back to the official node-q package for the extension, from the temporary one for development.