### PR TITLE
fix issue with no msg when you got disconnected

### DIFF
--- a/src/commands/serverCommand.ts
+++ b/src/commands/serverCommand.ts
@@ -783,15 +783,18 @@ export async function executeQuery(
     query = sanitizeQuery(query);
     const queryRes = await getScratchpadQuery(query, context);
     writeScratchpadResult(queryRes, query);
-  } else if (ext.connection !== undefined) {
+  } else if (ext.connection !== undefined && ext.connection.connected) {
     query = sanitizeQuery(query);
     const queryRes = await ext.connection.executeQuery(query, context);
     writeQueryResult(queryRes, query);
   } else {
+    const isConnected = ext.connection
+      ? ext.connection.connected
+      : !!ext.connection;
     queryConsole.appendQueryError(
       query,
       "Query is empty",
-      !!ext.connection,
+      isConnected,
       ext.connectionNode?.label ? ext.connectionNode.label : ""
     );
     return undefined;

--- a/src/utils/executionConsole.ts
+++ b/src/utils/executionConsole.ts
@@ -92,7 +92,9 @@ export class ExecutionConsole {
       this._console.appendLine(`ERROR Query executed: ${query}`);
       this._console.appendLine(result);
     } else {
+      window.showErrorMessage(`Please connect to a kdb+ server`);
       this._console.appendLine(`Please connect to a kdb+ server`);
+      commands.executeCommand("kdb.disconnect");
     }
     this._console.appendLine(`<<< >>>`);
   }


### PR DESCRIPTION
fix issues related to disconnection
- if the user get disconnected and execute query a msg will pop-up
- the connections list will refresh when the error popup