### PR TITLE
Update to newsletter url for notifications

### DIFF
--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -67,7 +67,7 @@ export namespace ext {
     "https://nexus.dl.kx.com/repository/kdb/4.0/";
 
   export const kdbNewsletterUrl =
-    "https://kx.com/?p=75762&post_type=landing_pages&preview=1&_ppp=e25811721a";
+    "https://kx.com/landing_pages/subscribe-to-our-kdb-vs-code-extension-newsletter";
 
   export const kxdevUrl =
     "https://downloads.kx.com/dl/index.php/9OeP-W7XAT7WtsH-I9lzPDKWiHw_oA8fK90mHgvuprPYhwcapsU1LNfQSoHOFinKpsgQ3VM5PWf7KjCpNgP9EqL_HvnorJxm0-ihvNzk2_rREPf8R1S1-Dt_Lz5uwxOhEWEcEO3PlFgY0dqsqt0Yd1cLLKhbKykjxKTR82XF1W6_ODzkJ0k3SNW4vt6xUkpdetckxbLdD1sUVYz1M0cMsAWsUWodLUpXcEi7ssuWfvvO-p8O2M-c-rAy9e8kz1ylEmh7OsWmX5-Zz8N1cvUyMQF54x3LEEFTpaJi96ZvmnjRMOSfkREHYVYsfzHM6XBALxVxxljdcmk6ttxqPEDuZUXQf6gdpjEeN5XPqrcv-zqKZhJ6A-PO6A1beCh5qlfJ3EyJFpdPBm0xnh8vCCENZ9BMGjAXUs8HQ7fukxWVRKX_sKLFeFFFKVsUJUJrgqop518iojQnKlx7QZnvArd0KA";


### PR DESCRIPTION
This updates the url used for vscode users that already have the Q runtime installed and install the extension.