### PR TITLE
[KXI-30633] - Incorrect URL redirection when user click on link to seek help on "No kdb servers registered" message

### DIFF
--- a/package.json
+++ b/package.json
@@ -356,7 +356,7 @@
     "viewsWelcome": [
       {
         "view": "kdb-servers",
-        "contents": "No kdb servers registered [learn more](https://www.bing.com).\n[Connect to kdb server](command:kdb.addConnection)"
+        "contents": "No kdb servers registered.\n[Connect to kdb server](command:kdb.addConnection)"
       }
     ],
     "menus": {


### PR DESCRIPTION
As discussed at [KXI-30633]: 
```
Chris Lo 

The link should point to the area of the documentations that describe the various connection types.

If the documentation is not going to be available in time, the short term solution is to remove the “learn more” link so that it avoids any confusion
```



