### PR TITLE
KXI-29031 Show stack trace on errors

### DIFF
--- a/resources/evaluate.q
+++ b/resources/evaluate.q
@@ -110,14 +110,14 @@
  if [err ~ enlist " ";
  err: "syntax error"];
  userCode: (-1 + last where (.Q.trp ~ first first @) each backtrace) # backtrace;
- callstack: {`name`text`index!(x[1;0]; x[1;3]; x 2)} each userCode;
- callstack[-1 + count callstack; `text]: (neg count suffix) _ (count prefix) _ (last callstack) `text;
- callstack[-1 + count callstack; `index]-: count prefix;
+ userCode[;3]: reverse 1 + til count userCode;
+ userCode[-1 + count userCode; 1; 3]: (neg count suffix) _ (count prefix) _ userCode[-1 + count userCode; 1; 3];
+ userCode[-1 + count userCode; 2]-: count prefix;
  (!) . flip (
  (`result;    ::);
  (`errored;   1b);
  (`error;     err);
- (`backtrace; callstack))
+ (`backtrace; .Q.sbt userCode))
  }[suffix; prefix]];
  if [isLastLine or result`errored;
  system "d ", cachedCtx;

--- a/src/models/connection.ts
+++ b/src/models/connection.ts
@@ -114,7 +114,10 @@ export class Connection {
           result = handleQueryResults(err.toString(), QueryResultType.Error);
         } else if (res) {
           if (res.errored) {
-            result = handleQueryResults(res.error, QueryResultType.Error);
+            result = handleQueryResults(
+              res.error + (res.backtrace ? "\n" + res.backtrace : ""),
+              QueryResultType.Error
+            );
           } else {
             result = res.result;
           }

--- a/src/utils/executionConsole.ts
+++ b/src/utils/executionConsole.ts
@@ -110,7 +110,7 @@ export class ExecutionConsole {
       `<<< ERROR -  ${serverName}  @ ${date.toLocaleTimeString()} >>>`
     );
     if (isConnected) {
-      this._console.appendLine(`ERROR Query executed: ${query}`);
+      this._console.appendLine(`ERROR Query executed: ${query}\n`);
       this._console.appendLine(result);
     } else {
       window.showErrorMessage(`Please connect to a kdb+ server`);


### PR DESCRIPTION
- modifies evaluate.q to use https://code.kx.com/q/ref/dotq/#sbt-string-backtrace
- adds the backtrace from above to result string