### PR TITLE
KX_31288 - KDB Results gives incorrect sort ordering

### DIFF
--- a/src/services/resultsPanelProvider.ts
+++ b/src/services/resultsPanelProvider.ts
@@ -142,15 +142,18 @@ export class KdbResultsViewProvider implements WebviewViewProvider {
     return !!this._view?.visible;
   }
 
-  sanitizeString(str: string | string[]): string {
-    if (str instanceof Array) {
-      str = str.join(" ");
+  sanitizeString(value: any): any {
+    if (value instanceof Array) {
+      value = value.join(" ");
     }
-    str = str.toString();
-    str = str.trim();
-    str = str.replace(/['"`]/g, "");
-    str = str.replace(/\$\{/g, "");
-    return str;
+    if (!isNaN(value)) {
+      return value;
+    }
+    value = value.toString();
+    value = value.trim();
+    value = value.replace(/['"`]/g, "");
+    value = value.replace(/\$\{/g, "");
+    return value;
   }
 
   defineAgGridTheme(): string {

--- a/test/suite/panels.test.ts
+++ b/test/suite/panels.test.ts
@@ -110,6 +110,14 @@ describe("WebPanels", () => {
         const actualString = resultsPanel.sanitizeString(inputString);
         assert.strictEqual(actualString, expectedString);
       });
+
+      it("should return a number", () => {
+        const inputString = 123;
+        const expectedString = 123;
+        const actualString = resultsPanel.sanitizeString(inputString);
+        assert.strictEqual(actualString, expectedString);
+        assert.ok(typeof actualString === "number");
+      });
     });
 
     describe("isVisible()", () => {
@@ -249,7 +257,7 @@ describe("WebPanels", () => {
           { id: 1, test: "test1" },
           { id: 2, test: "test2" },
         ];
-        const expectedOutput = `"rowData":[{"id":"1","test":"test1"},{"id":"2","test":"test2"}],"columnDefs":[{"field":"id","headerName":"id"},{"field":"test","headerName":"test"}]`;
+        const expectedOutput = `"rowData":[{"id":1,"test":"test1"},{"id":2,"test":"test2"}],"columnDefs":[{"field":"id","headerName":"id"},{"field":"test","headerName":"test"}]`;
         const actualOutput = resultsPanel["_getWebviewContent"](input);
         assert.strictEqual(typeof actualOutput, "string");
         assert.ok(actualOutput.includes(expectedOutput));


### PR DESCRIPTION
if the value from object is number, don't convert it in string
