### PR TITLE
KXI-31285 - Non-ascii characters aren't rendered

### DIFF
--- a/src/commands/serverCommand.ts
+++ b/src/commands/serverCommand.ts
@@ -70,6 +70,7 @@ import {
   updateServers,
 } from "../utils/core";
 import { refreshDataSourcesPanel } from "../utils/dataSource";
+import { decodeQUTF } from "../utils/decode";
 import { ExecutionConsole } from "../utils/executionConsole";
 import { openUrl } from "../utils/openUrl";
 import { handleWSResults, sanitizeQuery } from "../utils/queryUtils";
@@ -930,13 +931,15 @@ export function writeQueryResultsToConsole(
   dataSourceType?: string
 ): void {
   const queryConsole = ExecutionConsole.start();
-  const res = Array.isArray(result) ? result[0] : result;
+  const res = Array.isArray(result)
+    ? decodeQUTF(result[0])
+    : decodeQUTF(result);
   if (
     (ext.connection || ext.connectionNode) &&
     !res.startsWith(queryConstants.error)
   ) {
     queryConsole.append(
-      result,
+      res,
       query,
       ext.connectionNode?.label ? ext.connectionNode.label : "",
       dataSourceType

--- a/src/utils/decode.ts
+++ b/src/utils/decode.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 1998-2023 Kx Systems Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+/**
+ * Decodes a string encoded in Q-encoding format
+ * @param text The string to decode
+ * @returns The decoded string
+ */
+export function decodeQUTF(text: string): string {
+  if (typeof text === "undefined") {
+    return text;
+  }
+
+  return text.replace(/(\\[^0-7])|(\\[0-7]{3})+/g, (text, notOctal) => {
+    if (notOctal) {
+      return text;
+    }
+
+    return text
+      .replace(/\\[23][0-7]{2}/g, decodeOctal)
+      .split(
+        /((?:[\x00-\x7f]|[\xc0-\xdf][\x80-\xbf]|[\xe0-\xef][\x80-\xbf]{2}|[\xf0-\xf7][\x80-\xbf]{3}|[\u0100-\uFFFF])+)/
+      )
+      .map(decodeUnicode)
+      .join("");
+  });
+}
+
+/**
+ * Decodes a string encoded in Unicode format
+ * @param str The string to decode
+ * @param i The index of the string
+ * @returns The decoded string
+ */
+export function decodeUnicode(str: string, i: number): string {
+  const ODD_INDEX = 1;
+
+  if (i % 2 === ODD_INDEX) {
+    return str.replace(/[\x80-\xff]+/g, (encodedString) => {
+      let acc = "";
+      for (let j = 0; j < encodedString.length; j++) {
+        const num = encodedString.charCodeAt(j).toString(16);
+        acc += `%${num.length === 1 ? "0" : ""}${num}`;
+      }
+      try {
+        return decodeURIComponent(acc);
+      } catch (e) {
+        return toOctalEscapes(encodedString);
+      }
+    });
+  } else {
+    return toOctalEscapes(str);
+  }
+}
+
+/**
+ * Encodes non-ASCII characters in a string as octal escape sequences
+ * @param str The string to encode
+ * @returns The encoded string
+ */
+export function toOctalEscapes(str: string): string {
+  let acc = "";
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    acc += code < 128 ? str[i] : `\\${str.charCodeAt(i).toString(8)}`;
+  }
+  return acc;
+}
+
+/**
+ * Decodes an octal escape sequence to a character
+ * @param octalSequence The string that matched the regex
+ * @returns The decoded escape sequence
+ */
+export function decodeOctal(octalSequence: string): string {
+  return String.fromCharCode(parseInt(octalSequence.substring(1), 8));
+}

--- a/test/suite/utils.test.ts
+++ b/test/suite/utils.test.ts
@@ -25,6 +25,7 @@ import { QueryHistoryProvider } from "../../src/services/queryHistoryProvider";
 import { KdbResultsViewProvider } from "../../src/services/resultsPanelProvider";
 import * as coreUtils from "../../src/utils/core";
 import * as dataSourceUtils from "../../src/utils/dataSource";
+import * as decodeUtils from "../../src/utils/decode";
 import * as executionUtils from "../../src/utils/execution";
 import * as executionConsoleUtils from "../../src/utils/executionConsole";
 import { getNonce } from "../../src/utils/getNonce";
@@ -161,6 +162,54 @@ describe("Utils", () => {
         "2021-01-01"
       );
       assert.strictEqual(result2, false);
+    });
+  });
+
+  describe("decode", () => {
+    describe("decodeQUTF", () => {
+      it("should return undefined if the input is undefined", () => {
+        const result = decodeUtils.decodeQUTF(undefined);
+        assert.strictEqual(result, undefined);
+      });
+
+      it("should decode octal escape sequences in the input string", () => {
+        const input = "\\344\\275\\240\\345\\245\\275";
+        const expectedOutput = "你好";
+        const result = decodeUtils.decodeQUTF(input);
+        assert.strictEqual(result, expectedOutput);
+      });
+    });
+
+    describe("decodeUnicode", () => {
+      it("should return the input string if the index is even", () => {
+        const input = "hello";
+        const result = decodeUtils.decodeUnicode(input, 0);
+        assert.strictEqual(result, input);
+      });
+
+      it("should decode percent-encoded characters in the input string if the index is odd", () => {
+        const input = "ããç ãã¯ãªããªãªããªãªããª";
+        const expectedOutput = "もう眠くはないなないなないな";
+        const result = decodeUtils.decodeUnicode(input, 1);
+        assert.strictEqual(result, expectedOutput);
+      });
+    });
+
+    describe("toOctalEscapes", () => {
+      it("should return the input string if all characters have code points less than 128", () => {
+        const input = "hello";
+        const result = decodeUtils.toOctalEscapes(input);
+        assert.strictEqual(result, input);
+      });
+    });
+
+    describe("decodeOctal", () => {
+      it("should decode an octal escape sequence to a character", () => {
+        const input = "\\344";
+        const expectedOutput = "ä";
+        const result = decodeUtils.decodeOctal(input);
+        assert.strictEqual(result, expectedOutput);
+      });
     });
   });
 


### PR DESCRIPTION
- add decode utils
- add tests for decode utils
- add fix for output

console output:
![Screenshot 2023-11-09 at 12 01 43](https://github.com/KxSystems/kx-vscode/assets/126578219/ab775cac-35bb-4c9f-ab2e-197244487b56)
 result output:
 
![Screenshot 2023-11-09 at 12 01 55](https://github.com/KxSystems/kx-vscode/assets/126578219/b0a18c92-5a47-4494-9580-89028c4a05b6)
