### PR TITLE
KXI-35349: Disable testing on mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
A bug was introduced in the lastest version of vscode which causing our mac testing to fail. This will be disabled until this issue is addressed.
