### PR TITLE
KXI-35472: Add Execute Entire File context menu item to explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -313,6 +313,10 @@
         "command": "kdb.execute.pythonFileScratchpadQuery",
         "title": "Execute Entire File in Insights Scratchpad",
         "when": "kdb.connected"
+      },
+      {
+        "command": "kdb.execute.entireFile",
+        "title": "Execute Entire File"
       }
     ],
     "keybindings": [
@@ -628,6 +632,13 @@
           "command": "kdb.execute.pythonFileScratchpadQuery",
           "group": "q",
           "when": "editorLangId == python && kdb.insightsConnected"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "kdb.execute.entireFile",
+          "group": "q",
+          "when": "(resourceExtname == .q && (kdb.connected || kdb.insightsConnected)) || (resourceExtname == .py && kdb.insightsConnected)"
         }
       ]
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,6 +56,7 @@ import {
   connectInsights,
   disconnect,
   enableTLS,
+  executeQuery,
   removeConnection,
   removeInsightsConnection,
   runQuery,
@@ -299,7 +300,18 @@ export async function activate(context: ExtensionContext) {
         runQuery(ExecutionTypes.PythonQueryFile);
         ext.connection?.update();
       }
-    )
+    ),
+    commands.registerCommand("kdb.execute.entireFile", async (uri: Uri) => {
+      if (!uri) {
+        return;
+      }
+      const isPython = uri.fsPath.endsWith(".py");
+      if (uri.fsPath.endsWith(".q") || isPython) {
+        const content = await workspace.fs.readFile(uri);
+        const query = content.toString();
+        await executeQuery(query, undefined, isPython);
+      }
+    })
   );
 
   const lastResult: QueryResult | undefined = undefined;


### PR DESCRIPTION
### Changes introduced by this PR

- Added context menu item `Execute Entire File` for `.q` and `.py` files.
