### PR TITLE
KXI-33084: Insights remote connections; KXI-33419: User switching; KXI-33420: Failed login

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,6 +234,10 @@
         "title": "Remove connection"
       },
       {
+        "command": "kdb.insightsClear",
+        "title": "Clear authentication"
+      },
+      {
         "command": "kdb.disconnect",
         "title": "Disconnect"
       },
@@ -542,6 +546,11 @@
         },
         {
           "command": "kdb.insightsRemove",
+          "when": "view == kdb-servers && viewItem in kdb.insightsNodes",
+          "group": "connection"
+        },
+        {
+          "command": "kdb.insightsClear",
           "when": "view == kdb-servers && viewItem in kdb.insightsNodes",
           "group": "connection"
         },

--- a/src/commands/serverCommand.ts
+++ b/src/commands/serverCommand.ts
@@ -341,14 +341,6 @@ export async function removeConnection(viewItem: KdbNode): Promise<void> {
 }
 
 export async function connectInsights(viewItem: InsightsNode): Promise<void> {
-  if (env.remoteName === "ssh-remote") {
-    window.showErrorMessage(
-      "Connecting to a kdb Insights Enterprise server with a remote connection is not supported.",
-      ""
-    );
-    return;
-  }
-
   commands.executeCommand("kdb-results.focus");
 
   await getCurrentToken(viewItem.details.server, viewItem.details.alias);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -180,6 +180,12 @@ export async function activate(context: ExtensionContext) {
         await removeInsightsConnection(viewItem);
       }
     ),
+    commands.registerCommand(
+      "kdb.insightsClear",
+      async (viewItem: InsightsNode) => {
+        ext.context.secrets.delete(viewItem.label);
+      }
+    ),
     commands.registerCommand("kdb.disconnect", async () => {
       await disconnect();
     }),


### PR DESCRIPTION
### Changes introduced by this PR

Fixes the following related with insights connections:

- KXI-33084: Support Remote (& WSL) Environment connections for Insights login flow
- KXI-33419: No way to switch to a different user
- KXI-33420: Can't try again after failed login
