### PR TITLE
KXI-46005: Workbook and datasource files should be put into a dedicated folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,13 +213,15 @@
         "category": "KX",
         "command": "kdb.createDataSource",
         "title": "New Datasource...",
-        "icon": "$(add)"
+        "icon": "$(add)",
+        "enablement": "workspaceFolderCount > 0"
       },
       {
         "category": "KX",
         "command": "kdb.refreshDataSourceExplorer",
         "title": "Refresh datasources",
-        "icon": "$(refresh)"
+        "icon": "$(refresh)",
+        "enablement": "workspaceFolderCount > 0"
       },
       {
         "category": "KX",
@@ -228,7 +230,8 @@
         "icon": {
           "dark": "./resources/dark/add-scratchpad.svg",
           "light": "./resources/light/add-scratchpad.svg"
-        }
+        },
+        "enablement": "workspaceFolderCount > 0"
       },
       {
         "category": "KX",
@@ -237,13 +240,15 @@
         "icon": {
           "dark": "./resources/dark/add-scratchpad-python.svg",
           "light": "./resources/light/add-scratchpad-python.svg"
-        }
+        },
+        "enablement": "workspaceFolderCount > 0"
       },
       {
         "category": "KX",
         "command": "kdb.refreshScratchpadExplorer",
         "title": "Refresh workbooks",
-        "icon": "$(refresh)"
+        "icon": "$(refresh)",
+        "enablement": "workspaceFolderCount > 0"
       },
       {
         "category": "KX",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -324,6 +324,7 @@ export async function activate(context: ExtensionContext) {
             uri,
             DataSourceEditorProvider.viewType,
           );
+          await commands.executeCommand("workbench.action.files.save", uri);
         }
       },
     ),
@@ -336,6 +337,7 @@ export async function activate(context: ExtensionContext) {
         const uri = await addWorkspaceFile(item, "workbook", ".kdb.q");
         if (uri) {
           await window.showTextDocument(uri);
+          await commands.executeCommand("workbench.action.files.save", uri);
         }
       },
     ),
@@ -345,6 +347,7 @@ export async function activate(context: ExtensionContext) {
         const uri = await addWorkspaceFile(item, "workbook", ".kdb.py");
         if (uri) {
           await window.showTextDocument(uri);
+          await commands.executeCommand("workbench.action.files.save", uri);
         }
       },
     ),

--- a/src/services/workspaceTreeProvider.ts
+++ b/src/services/workspaceTreeProvider.ts
@@ -133,6 +133,7 @@ export async function addWorkspaceFile(
   item: FileTreeItem,
   name: string,
   ext: string,
+  directory = ".kx",
 ) {
   const folders = workspace.workspaceFolders;
   if (folders) {
@@ -143,7 +144,9 @@ export async function addWorkspaceFile(
     if (folder) {
       let i = 1;
       while (true) {
-        const files = await workspace.findFiles(`${name}-${i}${ext}`);
+        const files = await workspace.findFiles(
+          `${directory}/${name}-${i}${ext}`,
+        );
         if (files.length === 0) {
           break;
         }
@@ -152,11 +155,19 @@ export async function addWorkspaceFile(
           throw new Error("No available file name found");
         }
       }
-      const uri = Uri.joinPath(folder.uri, `${name}-${i}${ext}`).with({
+
+      const uri = Uri.joinPath(
+        folder.uri,
+        directory,
+        `${name}-${i}${ext}`,
+      ).with({
         scheme: "untitled",
       });
+
       await workspace.openTextDocument(uri);
       return uri;
     }
+  } else {
+    throw new Error("No workspace has been opened");
   }
 }


### PR DESCRIPTION
### Changes introduced by this PR

- When adding workbook or data source they are placed in `.kx` folder in workspace and saved.
- If no workspace is opened, the add commands are disabled.
