### PR TITLE
KXI-46682: Datasources and Workbooks remain when .kx folder is deleted

### DIFF
--- a/src/services/workspaceTreeProvider.ts
+++ b/src/services/workspaceTreeProvider.ts
@@ -23,7 +23,10 @@ import {
 } from "vscode";
 import Path from "path";
 import { getWorkspaceIconsState } from "../utils/core";
-import { getConnectionForUri } from "../commands/workspaceCommand";
+import {
+  getConnectionForUri,
+  setServerForUri,
+} from "../commands/workspaceCommand";
 import { ext } from "../extensionVariables";
 
 export class WorkspaceTreeProvider implements TreeDataProvider<FileTreeItem> {
@@ -165,6 +168,7 @@ export async function addWorkspaceFile(
       });
 
       await workspace.openTextDocument(uri);
+      await setServerForUri(uri, undefined);
       return uri;
     }
   } else {


### PR DESCRIPTION
### Changes introduced by this PR

- In case of .kx folder removal the views update accordingly
- Renaming of a data source or workbook keeps the previous connection association
- New data sources and workbooks are created with none connection association even the same name used before

