### PR TITLE
KXI-46862: Workbook execution on local KDB+ connections is broken

### DIFF
--- a/src/commands/workspaceCommand.ts
+++ b/src/commands/workspaceCommand.ts
@@ -245,6 +245,8 @@ export async function runActiveEditor(type?: ExecutionTypes) {
     if (!server) {
       server = "";
     }
+    const connection = await getConnectionForServer(server);
+    server = connection?.label || "";
     if (!connMngService.isConnected(server) && isScratchpad(uri)) {
       offerConnectAction(server);
       return;


### PR DESCRIPTION
### Changes introduced by this PR

- Get label for local server before sending to runQuery
