### PR TITLE
Fixes several connection related issues

### DIFF
--- a/src/classes/localConnection.ts
+++ b/src/classes/localConnection.ts
@@ -184,7 +184,7 @@ export class LocalConnection {
     );
 
     while (result === undefined || result === null) {
-      await delay(500);
+      await delay(50);
     }
 
     this.updateGlobal();

--- a/src/commands/installTools.ts
+++ b/src/commands/installTools.ts
@@ -50,7 +50,7 @@ import {
   addLocalConnectionStatus,
   convertBase64License,
   delay,
-  getHash,
+  getKeyForServerName,
   getOsFile,
   getServerName,
   getServers,
@@ -245,7 +245,7 @@ export async function installTools(): Promise<void> {
                 let servers: Server | undefined = getServers();
                 if (
                   servers != undefined &&
-                  servers[getHash(`localhost:${port}`)]
+                  servers[getKeyForServerName("local")]
                 ) {
                   Telemetry.sendEvent(
                     `Server localhost:${port} already exists in configuration store.`,
@@ -254,7 +254,7 @@ export async function installTools(): Promise<void> {
                     `Server localhost:${port} already exists.`,
                   );
                 } else {
-                  const key = getHash(`localhost${port}local`);
+                  const key = "local";
                   if (servers === undefined) {
                     servers = {
                       key: {
@@ -289,7 +289,7 @@ export async function installTools(): Promise<void> {
               }
               await startLocalProcessByServerName(
                 `localhost:${port} [local]`,
-                getHash(`localhost${port}local`),
+                getKeyForServerName("local"),
                 Number(port),
               );
             });

--- a/src/commands/serverCommand.ts
+++ b/src/commands/serverCommand.ts
@@ -41,8 +41,8 @@ import {
 import {
   addLocalConnectionContexts,
   checkOpenSslInstalled,
-  getHash,
   getInsights,
+  getKeyForServerName,
   getServerName,
   getServers,
   kdbOutputLog,
@@ -84,13 +84,16 @@ export async function addInsightsConnection(insightsData: InsightDetails) {
   }
 
   let insights: Insights | undefined = getInsights();
-  if (insights != undefined && insights[getHash(insightsData.server!)]) {
+  if (
+    insights != undefined &&
+    insights[getKeyForServerName(insightsData.alias)]
+  ) {
     await window.showErrorMessage(
       `Insights instance named ${insightsData.alias} already exists.`,
     );
     return;
   } else {
-    const key = getHash(insightsData.server!);
+    const key = insightsData.alias;
     if (insights === undefined) {
       insights = {
         key: {
@@ -214,18 +217,13 @@ export async function addKdbConnection(
 
   if (
     servers != undefined &&
-    servers[getHash(`${kdbData.serverName}:${kdbData.serverPort}`)]
+    servers[getKeyForServerName(kdbData.serverAlias || "")]
   ) {
     await window.showErrorMessage(
-      `Server ${kdbData.serverName}:${kdbData.serverPort} already exists.`,
+      `Server name ${kdbData.serverAlias} already exists.`,
     );
   } else {
-    const key =
-      kdbData.serverAlias != undefined
-        ? getHash(
-            `${kdbData.serverName}${kdbData.serverPort}${kdbData.serverAlias}`,
-          )
-        : getHash(`${kdbData.serverName}${kdbData.serverPort}`);
+    const key = kdbData.serverAlias || "";
     if (servers === undefined) {
       servers = {
         key: {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,6 +41,7 @@ import {
 } from "./commands/installTools";
 import {
   activeConnection,
+  addAuthConnection,
   addInsightsConnection,
   addKdbConnection,
   addNewConnection,
@@ -207,6 +208,25 @@ export async function activate(context: ExtensionContext) {
       "kdb.active.connection",
       async (viewItem: KdbNode) => {
         activeConnection(viewItem);
+      },
+    ),
+    commands.registerCommand(
+      "kdb.addAuthentication",
+      async (viewItem: KdbNode) => {
+        const username = await window.showInputBox({
+          prompt: "Username",
+          title: "Add Authentication",
+        });
+        if (username) {
+          const password = await window.showInputBox({
+            prompt: "Password",
+            title: "Add Authentication",
+            password: true,
+          });
+          if (password) {
+            await addAuthConnection(viewItem.children[0], username, password);
+          }
+        }
       },
     ),
     commands.registerCommand("kdb.enableTLS", async (viewItem: KdbNode) => {

--- a/src/services/connectionManagerService.ts
+++ b/src/services/connectionManagerService.ts
@@ -19,8 +19,8 @@ import { Telemetry } from "../utils/telemetryClient";
 import { InsightsConnection } from "../classes/insightsConnection";
 import { sanitizeQuery } from "../utils/queryUtils";
 import {
-  getHash,
   getInsights,
+  getKeyForServerName,
   getServerName,
   getServers,
   kdbOutputLog,
@@ -172,7 +172,7 @@ export class ConnectionManagementService {
     }
     if (connNode instanceof InsightsNode) {
       const insights = getInsights();
-      const key = getHash(connNode.details.server);
+      const key = getKeyForServerName(connNode.details.alias);
       if (insights && insights[key]) {
         const uInsights = Object.keys(insights).filter((insight) => {
           return insight !== key;
@@ -189,14 +189,7 @@ export class ConnectionManagementService {
     } else {
       const servers: Server | undefined = getServers();
 
-      const key =
-        connNode.details.serverAlias != ""
-          ? getHash(
-              `${connNode.details.serverName}${connNode.details.serverPort}${connNode.details.serverAlias}`,
-            )
-          : getHash(
-              `${connNode.details.serverName}${connNode.details.serverPort}`,
-            );
+      const key = getKeyForServerName(connNode.details.serverAlias || "");
       if (servers != undefined && servers[key]) {
         const uServers = Object.keys(servers).filter((server) => {
           return server !== key;

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -63,6 +63,26 @@ export function getHash(input: string): string {
   return createHash("sha256").update(input).digest("base64");
 }
 
+export function getKeyForServerName(name: string) {
+  const conf = workspace.getConfiguration("kdb");
+  const servers = conf.get<{ [key: string]: { serverAlias: string } }>(
+    "servers",
+    {},
+  );
+  let result = Object.keys(servers).find(
+    (key) => servers[key].serverAlias === name,
+  );
+  if (result) {
+    return result;
+  }
+  const insgihts = conf.get<{ [key: string]: { alias: string } }>(
+    "insightsEnterpriseConnections",
+    {},
+  );
+  result = Object.keys(insgihts).find((key) => insgihts[key].alias === name);
+  return result || "";
+}
+
 export function initializeLocalServers(servers: Server): void {
   Object.keys(servers!).forEach((server) => {
     if (servers![server].managed === true) {
@@ -370,7 +390,7 @@ export async function checkLocalInstall(): Promise<void> {
         ConfigurationTarget.Global,
       );
 
-    return;
+    //   return;
   }
 
   // set custom context that QHOME is not setup to control walkthrough visibility

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -390,7 +390,7 @@ export async function checkLocalInstall(): Promise<void> {
         ConfigurationTarget.Global,
       );
 
-    //   return;
+    return;
   }
 
   // set custom context that QHOME is not setup to control walkthrough visibility

--- a/src/validators/kdbValidator.ts
+++ b/src/validators/kdbValidator.ts
@@ -104,5 +104,7 @@ export function validateTls(input: string | undefined): string | undefined {
 }
 
 export function isAliasInUse(alias: string): boolean {
-  return ext.kdbConnectionAliasList.includes(alias);
+  return !!ext.kdbConnectionAliasList.find(
+    (item) => item.toLowerCase() === alias.toLowerCase(),
+  );
 }

--- a/test/suite/commands.test.ts
+++ b/test/suite/commands.test.ts
@@ -1706,6 +1706,7 @@ describe("serverCommand", () => {
       disconnectStub,
       getServersStub,
       getHashStub,
+      getKeyStub,
       getInsightsStub,
       removeLocalConnectionContextStub,
       updateServersStub,
@@ -1717,6 +1718,7 @@ describe("serverCommand", () => {
       getServersStub = sinon.stub(coreUtils, "getServers");
       getInsightsStub = sinon.stub(coreUtils, "getInsights");
       getHashStub = sinon.stub(coreUtils, "getHash");
+      getKeyStub = sinon.stub(coreUtils, "getKeyForServerName");
       removeLocalConnectionContextStub = sinon.stub(
         coreUtils,
         "removeLocalConnectionContext",
@@ -1735,7 +1737,7 @@ describe("serverCommand", () => {
     it("should remove connection and refresh server provider", async () => {
       indexOfStub.returns(1);
       getServersStub.returns({ testKey: {} });
-      getHashStub.returns("testKey");
+      getKeyStub.returns("testKey");
 
       await serverCommand.removeConnection(kdbNode);
 
@@ -1752,7 +1754,7 @@ describe("serverCommand", () => {
       ext.connectedContextStrings.push(kdbNode.label);
       indexOfStub.returns(1);
       getServersStub.returns({ testKey: {} });
-      getHashStub.returns("testKey");
+      getKeyStub.returns("testKey");
 
       await serverCommand.removeConnection(kdbNode);
       assert.ok(updateServersStub.calledOnce);


### PR DESCRIPTION
### Changes introduced by this PR

- 500 ms interval when executing query on KDB+ connections reduced to 50 ms
- Connection names are not case sensitive any more
- Same address can be used under different connection names
- Add authentication implemented for KDB+ connections which asks for credentials
- Connection settings in settings.json is now manually editable
- Changes are backwards compatible, user's current settings work as is
