### PR TITLE
Implement expand selection command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to the **kdb VS Code extension** are documented in this file
 - Extension changes scratchpad endpoints accordly to the Insights versions
 - Allow connection information in user settings to be editable
 - Allow same server address to be used in multiple connections
+- Language server features works on unsaved files
+- Expand Selection command is implemented
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -190,16 +190,14 @@ Set the following properties:
 
 Set the following from the Advanced properties if necessary:
 
-| Property               | Description                                                                                                                |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| Define Realm           | Specify the Keycloak realm for authentication. Usually the realm is set to `insights`, which is the default value used by the extension. You only need to change this field if a different realm has been configured on your server.  |
+| Property     | Description                                                                                                                                                                                                                          |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Define Realm | Specify the Keycloak realm for authentication. Usually the realm is set to `insights`, which is the default value used by the extension. You only need to change this field if a different realm has been configured on your server. |
 
 ![connecttoinsights](https://github.com/KxSystems/kx-vscode/blob/main/img/insightsconnectionadvanced.png?raw=true)
 
-
 !!!note "For kdb Insights Enterprise Free Trial instances"
-   The realm is configured as `insights-{URL}` where {URL} is the 10 digit code in the trial URL. For example: if your trial url is https://fstc83yi5b.ft1.cld.kx.com/ the realm should be `insights-fstc83yi5b`.
-
+The realm is configured as `insights-{URL}` where {URL} is the 10 digit code in the trial URL. For example: if your trial url is https://fstc83yi5b.ft1.cld.kx.com/ the realm should be `insights-fstc83yi5b`.
 
 1. Click **Create Connection** and the **kdb Insights Enterprise** connection appears under **CONNECTIONS** in the primary sidebar.
 
@@ -533,6 +531,16 @@ To update kdb VS Code settings, search for **kdb** from _Preferences_ > _Setting
         }
     }
 }
+```
+
+### Double Click Selection
+
+The following setting will change double click behaviour to select the whole identifier including dots:
+
+```JSON
+ "[q]": {
+    "editor.wordSeparators": "`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?"
+  }
 ```
 
 ## Shortcuts

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -492,7 +492,7 @@ export async function activate(context: ExtensionContext) {
     },
   };
   const clientOptions: LanguageClientOptions = {
-    documentSelector: [{ scheme: "file", language: "q" }],
+    documentSelector: [{ language: "q" }],
     synchronize: {
       fileEvents: workspace.createFileSystemWatcher("**/*.{q,quke}"),
     },

--- a/test/suite/qLangServer.test.ts
+++ b/test/suite/qLangServer.test.ts
@@ -56,6 +56,7 @@ describe("qLangServer", () => {
       onCompletion() {},
       onDidChangeConfiguration() {},
       onRequest() {},
+      onSelectionRanges() {},
     });
 
     const params = <InitializeParams>{
@@ -78,6 +79,7 @@ describe("qLangServer", () => {
       assert.ok(capabilities.definitionProvider);
       assert.ok(capabilities.renameProvider);
       assert.ok(capabilities.completionProvider);
+      assert.ok(capabilities.selectionRangeProvider);
     });
   });
 
@@ -313,6 +315,19 @@ describe("qLangServer", () => {
       const params = createDocument("");
       const result = server.onParameterCache(params);
       assert.strictEqual(result, null);
+    });
+  });
+
+  describe("onSelectionRanges", () => {
+    it("should return identifier range", () => {
+      const params = createDocument(".test.ref");
+      const result = server.onSelectionRanges({
+        textDocument: params.textDocument,
+        positions: [params.position],
+      });
+      assert.strictEqual(result.length, 1);
+      assert.strictEqual(result[0].range.start.character, 0);
+      assert.strictEqual(result[0].range.end.character, 9);
     });
   });
 });


### PR DESCRIPTION
### Changes introduced by this PR

- onSelectionRanges capability on LS is implemented so Expand Selection standart command works on q source
- LS features now work on newly created q and quke files
- Updated README for double click selection setting
- Updated CHANGELOG
