### PR TITLE
fix labels collapse at conn tree

### DIFF
--- a/src/services/kdbTreeProvider.ts
+++ b/src/services/kdbTreeProvider.ts
@@ -44,6 +44,7 @@ import { InsightsConnection } from "../classes/insightsConnection";
 import {
   getWorkspaceLabels,
   getWorkspaceLabelsConnMap,
+  isLabelEmpty,
   retrieveConnLabelsNames,
 } from "../utils/connLabel";
 import { Labels } from "../models/labels";
@@ -819,7 +820,12 @@ export class LabelNode extends TreeItem {
   readonly children: TreeItem[] = [];
 
   constructor(public readonly source: Labels) {
-    super(source.name, TreeItemCollapsibleState.Collapsed);
+    super(
+      source.name,
+      isLabelEmpty(source.name)
+        ? TreeItemCollapsibleState.None
+        : TreeItemCollapsibleState.Collapsed,
+    );
     this.contextValue = "label";
   }
 

--- a/src/utils/connLabel.ts
+++ b/src/utils/connLabel.ts
@@ -170,3 +170,11 @@ export function deleteLabel(name: string) {
     .getConfiguration()
     .update("kdb.connectionLabels", ext.connLabelList, true);
 }
+
+export function isLabelEmpty(name: string) {
+  const found = ext.labelConnMapList.find((item) => item.labelName === name);
+  if (found) {
+    return found.connections.length === 0;
+  }
+  return true;
+}

--- a/test/suite/utils.test.ts
+++ b/test/suite/utils.test.ts
@@ -1784,4 +1784,33 @@ describe("Utils", () => {
       assert.strictEqual(ext.connLabelList.length, 0);
     });
   });
+
+  describe("isLabelEmpty", () => {
+    beforeEach(() => {
+      ext.labelConnMapList.length = 0;
+    });
+
+    afterEach(() => {
+      ext.labelConnMapList.length = 0;
+    });
+    it("should return true if label is empty", () => {
+      ext.labelConnMapList.push({ labelName: "label1", connections: [] });
+      const result = LabelsUtils.isLabelEmpty("label1");
+      assert.strictEqual(result, true);
+    });
+
+    it("should return false if label is not empty", () => {
+      ext.labelConnMapList.push({
+        labelName: "label1",
+        connections: ["conn1"],
+      });
+      const result = LabelsUtils.isLabelEmpty("label1");
+      assert.strictEqual(result, false);
+    });
+
+    it("should return false if label is empty if label not on map list", () => {
+      const result = LabelsUtils.isLabelEmpty("label1");
+      assert.strictEqual(result, true);
+    });
+  });
 });


### PR DESCRIPTION
### Changes introduced by this PR

- Fix Error: Labels are collapsable without any connection under it

Now the labels without any connection under it are not expandable/collapsable
![image](https://github.com/user-attachments/assets/7bb9dd9c-2643-47da-9688-ecf303ae5de4)

