### PR TITLE
Fix for run q file not using the current editor contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,20 @@ All notable changes to the **kdb VS Code extension** are documented in this file
 
 ### Enhancements
 
+- Semantic highlighting for local variables
+- Display version of Insights server connected
+
 ### Fixes
 
 - Fix for results tab flickering , improving of UX
 - Fix for Issue [#382](https://github.com/KxSystems/kx-vscode/issues/382)
+- Fix for run q file not using the current editor contents
+- Fix for autocomplete for new and unsaved documents
+
+### Internal Improvements
+
+- Migrate to Shoelace Web Components
+- Move server object logic away from models code
 
 # v1.8.0
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -417,9 +417,20 @@ export async function activate(context: ExtensionContext) {
         await stopLocalProcess(viewItem);
       },
     ),
-    commands.registerCommand("kdb.terminal.run", () => {
-      const filename = ext.activeTextEditor?.document.fileName;
-      if (filename) runQFileTerminal(filename);
+    commands.registerCommand("kdb.terminal.run", async () => {
+      if (ext.activeTextEditor) {
+        const uri = Uri.joinPath(
+          ext.context.globalStorageUri,
+          "kdb-vscode-repl.q",
+        );
+        const text = ext.activeTextEditor.document.getText();
+        try {
+          await workspace.fs.writeFile(uri, Buffer.from(text, "utf-8"));
+          runQFileTerminal(`"${uri.fsPath}"`);
+        } catch (error) {
+          kdbOutputLog(`Unable to write temp file: ${error}`, "ERROR");
+        }
+      }
     }),
     commands.registerCommand("kdb.terminal.start", () => {
       if (env.QHOME) {


### PR DESCRIPTION
### Changes introduced by this PR

- Use contents of the current file for REPL
- Update CHANGELOG
