### PR TITLE
Add warning to datasource and workbook add commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,8 +234,7 @@
         "category": "KX",
         "command": "kdb.createDataSource",
         "title": "New Datasource...",
-        "icon": "$(add)",
-        "enablement": "workspaceFolderCount > 0"
+        "icon": "$(add)"
       },
       {
         "category": "KX",
@@ -251,8 +250,7 @@
         "icon": {
           "dark": "./resources/dark/add-scratchpad.svg",
           "light": "./resources/light/add-scratchpad.svg"
-        },
-        "enablement": "workspaceFolderCount > 0"
+        }
       },
       {
         "category": "KX",
@@ -261,8 +259,7 @@
         "icon": {
           "dark": "./resources/dark/add-scratchpad-python.svg",
           "light": "./resources/light/add-scratchpad-python.svg"
-        },
-        "enablement": "workspaceFolderCount > 0"
+        }
       },
       {
         "category": "KX",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,6 +82,7 @@ import {
   fixUnnamedAlias,
   getInsights,
   getServers,
+  hasWorkspaceOrShowOption,
   initializeLocalServers,
   kdbOutputLog,
 } from "./utils/core";
@@ -470,25 +471,27 @@ export async function activate(context: ExtensionContext) {
     commands.registerCommand(
       "kdb.createDataSource",
       async (item: FileTreeItem) => {
-        const uri = await addWorkspaceFile(item, "datasource", ".kdb.json");
+        if (hasWorkspaceOrShowOption()) {
+          const uri = await addWorkspaceFile(item, "datasource", ".kdb.json");
 
-        if (uri) {
-          const edit = new WorkspaceEdit();
+          if (uri) {
+            const edit = new WorkspaceEdit();
 
-          edit.replace(
-            uri,
-            new Range(0, 0, 1, 0),
-            JSON.stringify(createDefaultDataSourceFile(), null, 2),
-          );
+            edit.replace(
+              uri,
+              new Range(0, 0, 1, 0),
+              JSON.stringify(createDefaultDataSourceFile(), null, 2),
+            );
 
-          workspace.applyEdit(edit);
+            workspace.applyEdit(edit);
 
-          await commands.executeCommand(
-            "vscode.openWith",
-            uri,
-            DataSourceEditorProvider.viewType,
-          );
-          await commands.executeCommand("workbench.action.files.save", uri);
+            await commands.executeCommand(
+              "vscode.openWith",
+              uri,
+              DataSourceEditorProvider.viewType,
+            );
+            await commands.executeCommand("workbench.action.files.save", uri);
+          }
         }
       },
     ),
@@ -498,20 +501,24 @@ export async function activate(context: ExtensionContext) {
     commands.registerCommand(
       "kdb.createScratchpad",
       async (item: FileTreeItem) => {
-        const uri = await addWorkspaceFile(item, "workbook", ".kdb.q");
-        if (uri) {
-          await window.showTextDocument(uri);
-          await commands.executeCommand("workbench.action.files.save", uri);
+        if (hasWorkspaceOrShowOption()) {
+          const uri = await addWorkspaceFile(item, "workbook", ".kdb.q");
+          if (uri) {
+            await window.showTextDocument(uri);
+            await commands.executeCommand("workbench.action.files.save", uri);
+          }
         }
       },
     ),
     commands.registerCommand(
       "kdb.createPythonScratchpad",
       async (item: FileTreeItem) => {
-        const uri = await addWorkspaceFile(item, "workbook", ".kdb.py");
-        if (uri) {
-          await window.showTextDocument(uri);
-          await commands.executeCommand("workbench.action.files.save", uri);
+        if (hasWorkspaceOrShowOption()) {
+          const uri = await addWorkspaceFile(item, "workbook", ".kdb.py");
+          if (uri) {
+            await window.showTextDocument(uri);
+            await commands.executeCommand("workbench.action.files.save", uri);
+          }
         }
       },
     ),

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -635,6 +635,20 @@ export function formatTable(headers_: any, rows_: any, opts: any) {
   return result.join("\n");
 }
 
+export function hasWorkspaceOrShowOption() {
+  if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
+    return true;
+  }
+  window
+    .showWarningMessage("No workspace folder is opened.", "Open")
+    .then((res) => {
+      if (res === "Open") {
+        commands.executeCommand("workbench.action.files.openFolder");
+      }
+    });
+  return false;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function reduce(xs: any, f: any, init: any) {
   if (xs.reduce) {

--- a/test/suite/utils.test.ts
+++ b/test/suite/utils.test.ts
@@ -347,6 +347,25 @@ describe("Utils", () => {
         showErrorMessageSpy.calledWithMatch(connLabel);
       });
     });
+
+    describe("hasWorkspaceOrShowOption", () => {
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      it("should return true if a workspace folder is opened", () => {
+        sinon.stub(vscode.workspace, "workspaceFolders").get(() => [{}]);
+        const result = coreUtils.hasWorkspaceOrShowOption();
+        assert.strictEqual(result, true);
+      });
+
+      it("should return false and display message if no workspace", () => {
+        const stub = sinon.stub(vscode.window, "showWarningMessage").resolves();
+        const result = coreUtils.hasWorkspaceOrShowOption();
+        assert.strictEqual(result, false);
+        assert.ok(stub.calledOnce);
+      });
+    });
   });
 
   describe("dataSource", () => {


### PR DESCRIPTION
### Changes introduced by this PR

- Always enable datasource and workbook add commands
- Show option to open a workspace folder in case of no workspace
