### PR TITLE
Unified query progress for KDB+ and Insights

### DIFF
--- a/src/classes/insightsConnection.ts
+++ b/src/classes/insightsConnection.ts
@@ -403,9 +403,6 @@ export class InsightsConnection {
   ): Promise<any | undefined> {
     if (this.connected && this.connEndpoints) {
       const isTableView = ext.isResultsTabVisible;
-      const queryMsg = isStarting
-        ? "Starting scratchpad..."
-        : "Query is executing...";
       const scratchpadURL = new url.URL(
         this.connEndpoints.scratchpad.scratchpad,
         this.node.details.server,
@@ -456,7 +453,10 @@ export class InsightsConnection {
             kdbOutputLog(`User cancelled the Scrathpad execution.`, "WARNING");
           });
 
-          progress.report({ message: queryMsg });
+          if (isStarting) {
+            progress.report({ message: "Starting scratchpad..." });
+          }
+
           const spRes = await axios
             .post(scratchpadURL.toString(), body, {
               headers,

--- a/src/classes/insightsConnection.ts
+++ b/src/classes/insightsConnection.ts
@@ -450,7 +450,7 @@ export class InsightsConnection {
         },
         async (progress, token) => {
           token.onCancellationRequested(() => {
-            kdbOutputLog(`User cancelled the Scrathpad execution.`, "WARNING");
+            kdbOutputLog(`User cancelled the scratchpad execution.`, "WARNING");
           });
 
           if (isStarting) {

--- a/src/commands/dataSourceCommand.ts
+++ b/src/commands/dataSourceCommand.ts
@@ -170,7 +170,7 @@ export async function runDataSource(
           const resultCount = typeof res === "string" ? "0" : res.rows.length;
           kdbOutputLog(`[DATASOURCE] Results: ${resultCount} rows`, "INFO");
         }
-        writeQueryResultsToView(
+        await writeQueryResultsToView(
           success ? res : res.error,
           query,
           connLabel,
@@ -185,7 +185,7 @@ export async function runDataSource(
             "INFO",
           );
         }
-        writeQueryResultsToConsole(
+        await writeQueryResultsToConsole(
           success ? res : res.error,
           query,
           connLabel,

--- a/src/commands/serverCommand.ts
+++ b/src/commands/serverCommand.ts
@@ -797,7 +797,7 @@ export async function executeQuery(
     {
       cancellable: true,
       location: ProgressLocation.Window,
-      title: `Executing Query (${executorName})`,
+      title: `Executing query (${executorName})`,
     },
     async (_progress, token) => {
       await _executeQuery(

--- a/src/commands/serverCommand.ts
+++ b/src/commands/serverCommand.ts
@@ -15,7 +15,9 @@ import { readFileSync } from "fs-extra";
 import { join } from "path";
 import * as url from "url";
 import {
+  CancellationToken,
   Position,
+  ProgressLocation,
   Range,
   Uri,
   ViewColumn,
@@ -791,6 +793,37 @@ export async function executeQuery(
   isWorkbook: boolean,
   isFromConnTree?: boolean,
 ): Promise<void> {
+  await window.withProgress(
+    {
+      cancellable: true,
+      location: ProgressLocation.Window,
+      title: `Executing Query (${executorName})`,
+    },
+    async (_progress, token) => {
+      await _executeQuery(
+        query,
+        connLabel,
+        executorName,
+        context,
+        isPython,
+        isWorkbook,
+        isFromConnTree,
+        token,
+      );
+    },
+  );
+}
+
+async function _executeQuery(
+  query: string,
+  connLabel: string,
+  executorName: string,
+  context: string,
+  isPython: boolean,
+  isWorkbook: boolean,
+  isFromConnTree?: boolean,
+  token?: CancellationToken,
+): Promise<void> {
   const connMngService = new ConnectionManagementService();
   const queryConsole = ExecutionConsole.start();
   if (connLabel === "") {
@@ -842,9 +875,13 @@ export async function executeQuery(
   const endTime = Date.now();
   const duration = (endTime - startTime).toString();
 
+  if (token?.isCancellationRequested) {
+    return undefined;
+  }
+
   // set context for root nodes
   if (selectedConn instanceof InsightsConnection) {
-    writeScratchpadResult(
+    await writeScratchpadResult(
       results,
       query,
       connLabel,
@@ -875,7 +912,7 @@ export async function executeQuery(
         await setUriContent(uri, JSON.stringify(plot));
       }
     } else if (ext.isResultsTabVisible) {
-      writeQueryResultsToView(
+      await writeQueryResultsToView(
         results,
         query,
         connLabel,
@@ -888,7 +925,7 @@ export async function executeQuery(
         connVersion,
       );
     } else {
-      writeQueryResultsToConsole(
+      await writeQueryResultsToConsole(
         results,
         query,
         connLabel,
@@ -1123,7 +1160,7 @@ export async function exportConnections(connLabel?: string) {
   }
 }
 
-export function writeQueryResultsToConsole(
+export async function writeQueryResultsToConsole(
   result: string | string[],
   query: string,
   connLabel: string,
@@ -1133,7 +1170,7 @@ export function writeQueryResultsToConsole(
   isPython?: boolean,
   duration?: string,
   isFromConnTree?: boolean,
-): void {
+): Promise<void> {
   const queryConsole = ExecutionConsole.start();
   const isNonEmptyArray = Array.isArray(result) && result.length > 0;
   const valueToDecode = isNonEmptyArray ? result[0] : result.toString();
@@ -1169,7 +1206,7 @@ export function writeQueryResultsToConsole(
   }
 }
 
-export function writeQueryResultsToView(
+export async function writeQueryResultsToView(
   result: any,
   query: string,
   connLabel: string,
@@ -1180,8 +1217,8 @@ export function writeQueryResultsToView(
   duration?: string,
   isFromConnTree?: boolean,
   connVersion?: number,
-): void {
-  commands.executeCommand(
+): Promise<void> {
+  await commands.executeCommand(
     "kdb.resultsPanel.update",
     result,
     isInsights,
@@ -1204,7 +1241,7 @@ export function writeQueryResultsToView(
   }
 }
 
-export function writeScratchpadResult(
+export async function writeScratchpadResult(
   result: ScratchpadResult,
   query: string,
   connLabel: string,
@@ -1213,7 +1250,7 @@ export function writeScratchpadResult(
   isWorkbook: boolean,
   duration: string,
   connVersion: number,
-): void {
+): Promise<void> {
   let errorMsg;
 
   if (result.error) {
@@ -1226,7 +1263,7 @@ export function writeScratchpadResult(
   }
 
   if (ext.isResultsTabVisible) {
-    writeQueryResultsToView(
+    await writeQueryResultsToView(
       errorMsg ?? result,
       query,
       connLabel,
@@ -1239,7 +1276,7 @@ export function writeScratchpadResult(
       connVersion,
     );
   } else {
-    writeQueryResultsToConsole(
+    await writeQueryResultsToConsole(
       errorMsg ?? result.data,
       query,
       connLabel,

--- a/src/commands/serverCommand.ts
+++ b/src/commands/serverCommand.ts
@@ -875,6 +875,7 @@ async function _executeQuery(
   const endTime = Date.now();
   const duration = (endTime - startTime).toString();
 
+  /* istanbul ignore next */
   if (token?.isCancellationRequested) {
     return undefined;
   }


### PR DESCRIPTION
### Changes introduced by this PR

- Unified KDB+ and Insights connection query progress, now both displays the same notification in the status bar
- When clicked becomes a cancellable notification. Cancellation discards the results and does not display results (or plot).
