### PR TITLE
Update docs: Python code against kdb+ connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ For any file with a **.q** or **.py** extension there are additional options ava
 When executing Python code against kdb+ connections, **note** the following:
 
 - A Python variable is defined in the remote process `_kx_execution_context`, which means you need to explicitly accept it to avoid implicit changes to the remote process. It doesn’t make any other change to the remote process.
-- To write and execute Python code against kdb+ connections, make sure that `pykx` is loaded into the q process. If `.pykx` is undefined, it returns the following error: `.pykx is not defined: please load pykx`. For more information on getting started with pykx, refer to the [pykx quickstart](https://code.kx.com/pykx/3.0/getting-started/quickstart.html).
+- To write and execute Python code against kdb+ connections, make sure that `pykx` is loaded into the q process. If `.pykx` is undefined, it returns the following error: `.pykx is not defined: please load pykx`. PyKX is a Python-first interface to kdb+ and q. It helps users query and analyze huge amounts of in-memory and on-disk time-series data, significantly faster than other libraries. For more information on getting started with pykx, refer to the [pykx quickstart](https://code.kx.com/pykx/3.0/getting-started/quickstart.html).
 
 ### Insights query execution
 

--- a/README.md
+++ b/README.md
@@ -408,10 +408,7 @@ For any file with a **.q** or **.py** extension there are additional options ava
 When executing Python code against kdb+ connections, **note** the following:
 
 - A Python variable is defined in the remote process `_kx_execution_context`, which means you need to explicitly accept it to avoid implicit changes to the remote process. It doesn’t make any other change to the remote process.
-- To write and execute Python code against kdb+ connections, make sure that `pykx` is loaded into the q process. If `.pykx` is undefined, it returns the following error:
-  ```
-  .pykx is not defined: please load pykx
-  ```
+- To write and execute Python code against kdb+ connections, make sure that `pykx` is loaded into the q process. If `.pykx` is undefined, it returns the following error: `.pykx is not defined: please load pykx`
 
 ### Insights query execution
 

--- a/README.md
+++ b/README.md
@@ -405,6 +405,12 @@ For any file with a **.q** or **.py** extension there are additional options ava
 
 - **Run q file in new q instance** - If q is installed and executable from the terminal you can execute an entire q script on a newly launched q instance. Executing a file on a new instance is done in the terminal, and allows interrogation of the active q process from the terminal window.
 
+**Note**: To write and execute Python code against kdb+ connections, make sure that `pykx` is loaded into the q process. If `.pykx` is undefined, it returns the following error:
+
+```
+.pykx is not defined: please load pykx
+```
+
 ### Insights query execution
 
 **kdb Insights Enterprise** offers enhanced connectivity and enterprise level API endpoints, providing additional means to query data and interact with **kdb Insights Enterprise** that are not available with standard kdb processes. You must have an instance of **kdb Insights Enterprise** running, and have created a [connection](#connections) within the **kdb VS Code extension**.

--- a/README.md
+++ b/README.md
@@ -405,11 +405,13 @@ For any file with a **.q** or **.py** extension there are additional options ava
 
 - **Run q file in new q instance** - If q is installed and executable from the terminal you can execute an entire q script on a newly launched q instance. Executing a file on a new instance is done in the terminal, and allows interrogation of the active q process from the terminal window.
 
-!!!warning "Prerequisite for executing Python code against kdb+ connections"
-   To write and execute Python code against kdb+ connections, make sure that `pykx` is loaded into the q process. If `.pykx` is undefined, it returns the following error:
-   ```
-   .pykx is not defined: please load pykx
-   ```
+When executing Python code against kdb+ connections, **note** the following:
+
+- A Python variable is defined in the remote process `_kx_execution_context`, which means you need to explicitly accept it to avoid implicit changes to the remote process. It doesn’t make any other change to the remote process.
+- To write and execute Python code against kdb+ connections, make sure that `pykx` is loaded into the q process. If `.pykx` is undefined, it returns the following error:
+  ```
+  .pykx is not defined: please load pykx
+  ```
 
 ### Insights query execution
 

--- a/README.md
+++ b/README.md
@@ -405,11 +405,11 @@ For any file with a **.q** or **.py** extension there are additional options ava
 
 - **Run q file in new q instance** - If q is installed and executable from the terminal you can execute an entire q script on a newly launched q instance. Executing a file on a new instance is done in the terminal, and allows interrogation of the active q process from the terminal window.
 
-**Note**: To write and execute Python code against kdb+ connections, make sure that `pykx` is loaded into the q process. If `.pykx` is undefined, it returns the following error:
-
-```
-.pykx is not defined: please load pykx
-```
+!!!warning "Prerequisite for executing Python code against kdb+ connections"
+   To write and execute Python code against kdb+ connections, make sure that `pykx` is loaded into the q process. If `.pykx` is undefined, it returns the following error:
+   ```
+   .pykx is not defined: please load pykx
+   ```
 
 ### Insights query execution
 

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ For any file with a **.q** or **.py** extension there are additional options ava
 When executing Python code against kdb+ connections, **note** the following:
 
 - A Python variable is defined in the remote process `_kx_execution_context`, which means you need to explicitly accept it to avoid implicit changes to the remote process. It doesn’t make any other change to the remote process.
-- To write and execute Python code against kdb+ connections, make sure that `pykx` is loaded into the q process. If `.pykx` is undefined, it returns the following error: `.pykx is not defined: please load pykx`
+- To write and execute Python code against kdb+ connections, make sure that `pykx` is loaded into the q process. If `.pykx` is undefined, it returns the following error: `.pykx is not defined: please load pykx`. For more information on getting started with pykx, refer to the [pykx quickstart](https://code.kx.com/pykx/3.0/getting-started/quickstart.html).
 
 ### Insights query execution
 


### PR DESCRIPTION
### Changes introduced by this PR
- Update the "kdb process executing q and Python code" section to add the prerequisite for executing Python code against kdb+ connections (Jira ticket: [Add support for Python in non-scratchpad processes](https://kxl.atlassian.net/browse/KXI-37307))

-
