### PR TITLE
Workaround for Python structuredText bug

### DIFF
--- a/src/classes/insightsConnection.ts
+++ b/src/classes/insightsConnection.ts
@@ -430,7 +430,8 @@ export class InsightsConnection {
       };
 
       if (this.insightsVersion) {
-        if (compareVersions(this.insightsVersion, 1.12)) {
+        /* TODO: Workaround for Python structuredText bug */
+        if (!isPython && compareVersions(this.insightsVersion, 1.12)) {
           body.returnFormat = isTableView ? "structuredText" : "text";
         } else {
           body.isTableView = isTableView;
@@ -475,6 +476,8 @@ export class InsightsConnection {
                 if (!response.data.error) {
                   if (isTableView) {
                     if (
+                      /* TODO: Workaround for Python structuredText bug */
+                      !isPython &&
                       this.insightsVersion &&
                       compareVersions(this.insightsVersion, 1.12)
                     ) {

--- a/src/services/resultsPanelProvider.ts
+++ b/src/services/resultsPanelProvider.ts
@@ -241,7 +241,8 @@ export class KdbResultsViewProvider implements WebviewViewProvider {
 
     if (
       (!isInsights && !isPython) ||
-      (isInsights && connVersion && compareVersions(connVersion, 1.12))
+      /* TODO: Workaround for Python structuredText bug */
+      (!isPython && connVersion && compareVersions(connVersion, 1.12))
     ) {
       rowData = this.updatedExtractRowData(results);
       columnDefs = this.updatedExtractColumnDefs(results);


### PR DESCRIPTION
### Changes introduced by this PR

- Use serialized (old) code path for Python queries on Insights scratchpad for KDB Results view
