### PR TITLE
KXI-59061 Handle errors from iasc when building structuredText output

### DIFF
--- a/resources/evaluate.q
+++ b/resources/evaluate.q
@@ -141,6 +141,7 @@
   text
   };
   generateColumns:{[removeTrailingNewline; toString; originalType; isAtom; isKey; data; name]
+  attributes: attr data;
   types: $[
   isAtom;
   originalType;
@@ -149,10 +150,11 @@
   .axq.i_NONPRIMCODE type data];
   values: ('[removeTrailingNewline; toString] each data);
   values: $[type values = 11h; enlist values; values];
-  order: $[1 ~ count data; iasc enlist data; iasc data];
+  formatData: $[1 ~ count data; enlist data; data];
+  order:@[{iasc x}; formatData; {"Not Yet Implemented for the input"}];
   returnDictionary: `name`type`values`order!(name;types;values;order);
   if[isKey; returnDictionary[`isKey]: isKey];
-  if[attr[data] <> `; returnDictionary[`attributes]: attr data];
+  if[attributes <> `; returnDictionary[`attributes]: attributes];
   :returnDictionary
   }[removeTrailingNewline;toString];
   generateTableColumns:{[generateColumns; originalType; isAtom; isKey; data]


### PR DESCRIPTION
q bug with iasc that fails for (symbol; long), so we need to handle this error Also fixes a different q bug - a side effect of iasc that applies a `s attribute if the data is sorted, so we cache the data attributes before applying iasc to the data

### Changes introduced by this PR

-
