### PR TITLE
[structuredText] Refactor for API changes

### DIFF
--- a/resources/evaluate.q
+++ b/resources/evaluate.q
@@ -144,6 +144,7 @@
   text
   };
   generateColumns:{[removeTrailingNewline; toString; originalType; isAtomic; isKey; data; name]
+  attributes: attr data;
   types: $[
   isAtomic;
   originalType;

--- a/src/models/queryResult.ts
+++ b/src/models/queryResult.ts
@@ -40,15 +40,16 @@ export const queryConstants = {
 };
 
 export interface StructuredTextColumns {
-  name: "values" | "value" | string;
+  name: string;
   type: string;
   values: string[] | string;
-  /* not the order for initial display */
-  order: number[] | "Not Yet Implemented for the input";
+  order:
+    | number[] /* ascending indexes if the column is sorted */
+    | string /* error message if sorting is not possible */;
 }
 
 export interface StructuredTextResults {
   columns: StructuredTextColumns[] | StructuredTextColumns;
-  /* values array length may differ */
+  /* note: values array length may differ */
   count: number;
 }

--- a/src/models/queryResult.ts
+++ b/src/models/queryResult.ts
@@ -40,12 +40,15 @@ export const queryConstants = {
 };
 
 export interface StructuredTextColumns {
-  name: string;
+  name: "values" | "value" | string;
   type: string;
-  values: any[];
-  order: any[];
+  values: string[] | string;
+  /* not the order for initial display */
+  order: number[] | "Not Yet Implemented for the input";
 }
+
 export interface StructuredTextResults {
-  columns: StructuredTextColumns[];
+  columns: StructuredTextColumns[] | StructuredTextColumns;
+  /* values array length may differ */
   count: number;
 }

--- a/src/services/resultsPanelProvider.ts
+++ b/src/services/resultsPanelProvider.ts
@@ -227,7 +227,7 @@ export class KdbResultsViewProvider implements WebviewViewProvider {
 
     const columnDefs = columnsArray.map((column) => {
       const sanitizedKey = this.sanitizeString(column.name);
-      const cellDataType = this.kdbToAgGridCellType(column.type);
+      const cellDataType = "text";
       const headerName = column.type
         ? `${sanitizedKey} [${column.type}]`
         : sanitizedKey;
@@ -236,7 +236,7 @@ export class KdbResultsViewProvider implements WebviewViewProvider {
         field: column.name,
         headerName: headerName,
         cellDataType: cellDataType,
-        cellRendererParams: { disabled: cellDataType === "boolean" },
+        cellRendererParams: { disabled: false },
       };
     });
 

--- a/src/services/resultsPanelProvider.ts
+++ b/src/services/resultsPanelProvider.ts
@@ -211,7 +211,8 @@ export class KdbResultsViewProvider implements WebviewViewProvider {
 
     columnsArray.forEach((column) => {
       const { name, values } = column;
-      values.forEach((value, index) => {
+      const valuesArray = Array.isArray(values) ? values : [values];
+      valuesArray.forEach((value, index) => {
         rowData[index][name] = decodeQUTF(value);
       });
     });

--- a/src/utils/queryUtils.ts
+++ b/src/utils/queryUtils.ts
@@ -399,8 +399,9 @@ export function formatScratchpadStacktrace(stacktrace: ScratchpadStacktrace) {
 const PNG = ["0x89", "0x50", "0x4e", "0x47", "0x0d", "0x0a", "0x1a", "0x0a"];
 
 export function resultToBase64(result: any): string | undefined {
-  const bytes =
-    result?.columns?.type === "bytes" ? result.columns.values : result;
+  const bytes = Array.isArray(result?.columns)
+    ? result.columns[0].values
+    : result?.columns?.values || result;
   if (Array.isArray(bytes) && bytes.length > 66) {
     for (let i = 0; i < PNG.length; i++) {
       if (bytes[i] !== PNG[i] && bytes[i] !== parseInt(PNG[i], 16)) {

--- a/src/utils/queryUtils.ts
+++ b/src/utils/queryUtils.ts
@@ -399,9 +399,10 @@ export function formatScratchpadStacktrace(stacktrace: ScratchpadStacktrace) {
 const PNG = ["0x89", "0x50", "0x4e", "0x47", "0x0d", "0x0a", "0x1a", "0x0a"];
 
 export function resultToBase64(result: any): string | undefined {
-  const bytes = Array.isArray(result?.columns)
-    ? result.columns[0].values
-    : result?.columns?.values || result;
+  const bytes =
+    (Array.isArray(result?.columns) && result.columns[0]?.values) ||
+    result?.columns?.values ||
+    result;
   if (Array.isArray(bytes) && bytes.length > 66) {
     for (let i = 0; i < PNG.length; i++) {
       if (bytes[i] !== PNG[i] && bytes[i] !== parseInt(PNG[i], 16)) {

--- a/test/suite/utils.test.ts
+++ b/test/suite/utils.test.ts
@@ -2035,7 +2035,7 @@ describe("Utils", () => {
     });
     it("should return undefined for bogus structuredText v2", () => {
       const result = queryUtils.resultToBase64({
-        columns: [{}],
+        columns: [],
       });
       assert.strictEqual(result, undefined);
     });

--- a/test/suite/utils.test.ts
+++ b/test/suite/utils.test.ts
@@ -2017,13 +2017,25 @@ describe("Utils", () => {
     });
     it("should return base64 for minimum img str for structuredText", () => {
       const result = queryUtils.resultToBase64({
-        columns: { type: "bytes", values: [...png, ...img] },
+        columns: { values: [...png, ...img] },
+      });
+      assert.ok(result.startsWith("data:image/png;base64"));
+    });
+    it("should return base64 for minimum img str for structuredText v2", () => {
+      const result = queryUtils.resultToBase64({
+        columns: [{ values: [...png, ...img] }],
       });
       assert.ok(result.startsWith("data:image/png;base64"));
     });
     it("should return undefined for bogus structuredText", () => {
       const result = queryUtils.resultToBase64({
-        columns: { type: "bytes" },
+        columns: {},
+      });
+      assert.strictEqual(result, undefined);
+    });
+    it("should return undefined for bogus structuredText v2", () => {
+      const result = queryUtils.resultToBase64({
+        columns: [{}],
       });
       assert.strictEqual(result, undefined);
     });


### PR DESCRIPTION
### Changes introduced by this PR

- Refactoring for structuredText API changes
- Always use "text" for table columns 
