### PR TITLE
[Bug] Fixed png detection from a windows q server

### DIFF
--- a/src/utils/queryUtils.ts
+++ b/src/utils/queryUtils.ts
@@ -396,7 +396,7 @@ export function formatScratchpadStacktrace(stacktrace: ScratchpadStacktrace) {
     .join("\n");
 }
 
-const PNG = ["0x89", "0x50", "0x4e", "0x47", "0x0d", "0x0a", "0x1a", "0x0a"];
+const PNG = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 
 export function resultToBase64(result: any): string | undefined {
   const bytes =
@@ -405,7 +405,7 @@ export function resultToBase64(result: any): string | undefined {
     result;
   if (Array.isArray(bytes) && bytes.length > 66) {
     for (let i = 0; i < PNG.length; i++) {
-      if (bytes[i] !== PNG[i] && bytes[i] !== parseInt(PNG[i], 16)) {
+      if (parseInt(`${bytes[i]}`) !== PNG[i]) {
         return undefined;
       }
     }

--- a/test/suite/utils.test.ts
+++ b/test/suite/utils.test.ts
@@ -1996,36 +1996,35 @@ describe("Utils", () => {
       const result = queryUtils.resultToBase64(png);
       assert.strictEqual(result, undefined);
     });
-    it("should return undefined for undefined for bad signature", () => {
+    it("should return undefined for bad signature", () => {
       const result = queryUtils.resultToBase64([
         ...png.map((v) => parseInt(v, 16) + 1),
-        ,
         ...img,
       ]);
       assert.strictEqual(result, undefined);
     });
     it("should return base64 for minimum img str", () => {
       const result = queryUtils.resultToBase64([...png, ...img]);
-      assert.ok(result.startsWith("data:image/png;base64"));
+      assert.ok(result);
     });
     it("should return base64 for minimum img num", () => {
       const result = queryUtils.resultToBase64([
         ...png.map((v) => parseInt(v, 16)),
         ...img.map((v) => parseInt(v, 16)),
       ]);
-      assert.ok(result.startsWith("data:image/png;base64"));
+      assert.ok(result);
     });
     it("should return base64 for minimum img str for structuredText", () => {
       const result = queryUtils.resultToBase64({
         columns: { values: [...png, ...img] },
       });
-      assert.ok(result.startsWith("data:image/png;base64"));
+      assert.ok(result);
     });
     it("should return base64 for minimum img str for structuredText v2", () => {
       const result = queryUtils.resultToBase64({
         columns: [{ values: [...png, ...img] }],
       });
-      assert.ok(result.startsWith("data:image/png;base64"));
+      assert.ok(result);
     });
     it("should return undefined for bogus structuredText", () => {
       const result = queryUtils.resultToBase64({
@@ -2038,6 +2037,13 @@ describe("Utils", () => {
         columns: [],
       });
       assert.strictEqual(result, undefined);
+    });
+    it("should return base64 from windows q server", () => {
+      const result = queryUtils.resultToBase64([
+        ...png.map((v) => `${v}\r`),
+        ...img.map((v) => `${v}\r`),
+      ]);
+      assert.ok(result);
     });
   });
 });


### PR DESCRIPTION
### Changes introduced by this PR

- q server running on windows append an invisible “\r” on bytes like “0x89\r” which is handled with this.
- test case is added
