### PR TITLE
Fixes for bugs found by Peter

### DIFF
--- a/src/services/resultsPanelProvider.ts
+++ b/src/services/resultsPanelProvider.ts
@@ -499,6 +499,7 @@ export class KdbResultsViewProvider implements WebviewViewProvider {
                     maxConcurrentDatasourceRequests: 1,
                     infiniteInitialRowCount: 10000,
                     maxBlocksInCache: 10,
+                    overlayNoRowsTemplate: '<span class="ag-overlay-loading-center">No results to show</span>',
                     datasource: {
                       rowCount: undefined,
                       getRows: function(params) {
@@ -506,6 +507,11 @@ export class KdbResultsViewProvider implements WebviewViewProvider {
                         const results = message.results;
                         setTimeout(() => {
                           const lastRow = results.length;
+                          if (lastRow === 0) {
+                            gridApi.showNoRowsOverlay();
+                          } else {
+                            gridApi.hideOverlay();
+                          }
                           const rowsThisPage = results.slice(params.startRow, params.endRow);
                           params.successCallback(rowsThisPage, lastRow);
                           hideOverlay();

--- a/src/webview/components/kdbNewConnectionView.ts
+++ b/src/webview/components/kdbNewConnectionView.ts
@@ -63,6 +63,7 @@ export class KdbNewConnectionView extends LitElement {
   isBundledQ: boolean = true;
   oldAlias: string = "";
   editAuth: boolean = false;
+  private renderId: string = "";
   private isModalOpen = false;
   private _connectionData: EditConnectionMessage | undefined = undefined;
   private readonly vscode = acquireVsCodeApi();
@@ -144,7 +145,6 @@ export class KdbNewConnectionView extends LitElement {
 
   handleMessage(event: { data: any }) {
     const message = event.data;
-    console.log(message);
     if (message.command === "editConnection") {
       this.connectionData = message.data;
       this.labels = message.labels;
@@ -397,15 +397,12 @@ export class KdbNewConnectionView extends LitElement {
   }
 
   renderLblDropdownOptions(pos: number) {
-    console.log(this.labels);
     return html`
       <sl-option> No Label Selected </sl-option>
       ${repeat(
         this.lblNamesList,
         (lbl) => lbl,
         (lbl) => {
-          console.log(lbl.name);
-          console.log(lbl.name === this.labels[pos]);
           return html`
             <sl-option .value="${encodeURIComponent(lbl.name)}">
               <span>
@@ -749,7 +746,13 @@ export class KdbNewConnectionView extends LitElement {
       return html`<div>No connection found to be edited</div>`;
     }
     this.isBundledQ = this.connectionData.connType === ConnectionType.BundledQ;
-    this.oldAlias = this.connectionData.serverName;
+    if (
+      this.renderId === "" ||
+      this.oldAlias !== this.connectionData.serverName
+    ) {
+      this.oldAlias = this.connectionData.serverName;
+      this.renderId = "";
+    }
     const connTypeName = this.defineConnTypeName(this.connectionData.connType);
     this.serverType =
       this.connectionData.connType === ConnectionType.Insights
@@ -813,9 +816,14 @@ export class KdbNewConnectionView extends LitElement {
     if (!this.connectionData) {
       return html`<div>No connection found to be edited</div>`;
     }
-    this.bundledServer.serverAlias = "local";
-    this.bundledServer.serverPort = this.connectionData.port ?? "";
-    this.bundledServer.serverName = this.connectionData.serverAddress;
+
+    if (this.renderId === "") {
+      this.renderId = this.generateRenderId();
+      this.bundledServer.serverAlias = "local";
+      this.bundledServer.serverPort = this.connectionData.port ?? "";
+      this.bundledServer.serverName = this.connectionData.serverAddress;
+    }
+
     return html`
       <div class="col">
         <div class="row">
@@ -839,11 +847,16 @@ export class KdbNewConnectionView extends LitElement {
     if (!this.connectionData) {
       return html`<div>No connection found to be edited</div>`;
     }
-    this.kdbServer.serverAlias = this.connectionData.serverName;
-    this.kdbServer.serverPort = this.connectionData.port ?? "";
-    this.kdbServer.serverName = this.connectionData.serverAddress;
-    this.kdbServer.auth = this.connectionData.auth ?? false;
-    this.kdbServer.tls = this.connectionData.tls ?? false;
+
+    if (this.renderId === "") {
+      this.renderId = this.generateRenderId();
+      this.kdbServer.serverAlias = this.connectionData.serverName;
+      this.kdbServer.serverPort = this.connectionData.port ?? "";
+      this.kdbServer.serverName = this.connectionData.serverAddress;
+      this.kdbServer.auth = this.connectionData.auth ?? false;
+      this.kdbServer.tls = this.connectionData.tls ?? false;
+    }
+
     return html`
       <div class="col">
         <div class="row">
@@ -926,9 +939,14 @@ export class KdbNewConnectionView extends LitElement {
     if (!this.connectionData) {
       return html`<div>No connection found to be edited</div>`;
     }
-    this.insightsServer.alias = this.connectionData.serverName;
-    this.insightsServer.server = this.connectionData.serverAddress;
-    this.insightsServer.realm = this.connectionData.realm ?? "";
+
+    if (this.renderId === "") {
+      this.renderId = this.generateRenderId();
+      this.insightsServer.alias = this.connectionData.serverName;
+      this.insightsServer.server = this.connectionData.serverAddress;
+      this.insightsServer.realm = this.connectionData.realm ?? "";
+    }
+
     return html`
       <div class="col">
         <div class="row">
@@ -1041,6 +1059,12 @@ export class KdbNewConnectionView extends LitElement {
         labels: this.labels,
       });
     }
+  }
+
+  private generateRenderId(): string {
+    const timestamp = new Date().getTime();
+    const random = Math.random().toString(36).substring(2, 8);
+    return `render-${timestamp}-${random}`;
   }
 }
 


### PR DESCRIPTION
### Changes introduced by this PR

- Data sources :warning: when no results it shows empty table but no longer says “no results”
- Editing name and adding connection work in tandem :x: When the user edits the name of a connection while adding a new label, only the newly created label is added and the connection is not renamed - also happens when adding to a existing label group (video attached to ticket)
