### PR TITLE
Pass connection labels to custom auth

### DIFF
--- a/src/classes/localConnection.ts
+++ b/src/classes/localConnection.ts
@@ -22,6 +22,7 @@ import { QueryResult, QueryResultType } from "../models/queryResult";
 export class LocalConnection {
   public connected: boolean;
   public connLabel: string;
+  public labels: string[];
   private options: nodeq.ConnectionParameters;
   private connection?: nodeq.Connection;
   private isError: boolean = false;
@@ -30,6 +31,7 @@ export class LocalConnection {
   constructor(
     connectionString: string,
     connLabel: string,
+    labels: string[],
     creds?: string[],
     tls?: boolean,
   ) {
@@ -62,6 +64,7 @@ export class LocalConnection {
     }
 
     this.connLabel = connLabel;
+    this.labels = labels;
     this.options = options;
     this.connected = false;
   }
@@ -373,7 +376,8 @@ export class LocalConnection {
   async getCustomAuthOptions(): Promise<nodeq.ConnectionParameters> {
     if (ext.customAuth) {
       const { kdb } = await ext.customAuth.auth({
-        label: this.connLabel,
+        name: this.connLabel,
+        labels: this.labels,
         kdb: {
           host: this.options.host,
           port: this.options.port,

--- a/src/models/customAuth.ts
+++ b/src/models/customAuth.ts
@@ -12,7 +12,8 @@
  */
 
 export interface CustomAuthParams {
-  label: string;
+  name: string;
+  labels: string[];
   kdb?: {
     host?: string;
     port?: number;

--- a/src/services/connectionManagerService.ts
+++ b/src/services/connectionManagerService.ts
@@ -137,6 +137,7 @@ export class ConnectionManagementService {
       const localConnection = new LocalConnection(
         connectionString,
         connLabel,
+        retrieveConnLabelsNames(connection),
         authCredentials ? authCredentials.split(":") : undefined,
         connection.details.tls,
       );

--- a/test/suite/classes.test.ts
+++ b/test/suite/classes.test.ts
@@ -25,7 +25,7 @@ describe("LocalConnection", () => {
   let getConnectionStub: sinon.SinonStub;
 
   beforeEach(() => {
-    localConn = new LocalConnection("127.0.0.1:5001", "testLabel");
+    localConn = new LocalConnection("127.0.0.1:5001", "testLabel", []);
     connectStub = sinon.stub(localConn, "connect");
     disconnectStub = sinon.stub(localConn, "disconnect");
     getConnectionStub = sinon.stub(localConn, "getConnection");
@@ -38,7 +38,7 @@ describe("LocalConnection", () => {
   });
 
   it("Should create a new connection object", () => {
-    const conn = new LocalConnection("server:5001", "server1");
+    const conn = new LocalConnection("server:5001", "server1", []);
     assert.strictEqual(
       conn.connected,
       false,
@@ -50,6 +50,7 @@ describe("LocalConnection", () => {
     const conn = new LocalConnection(
       "server:5001",
       "server1",
+      [],
       ["username", "password"],
       true,
     );
@@ -61,7 +62,7 @@ describe("LocalConnection", () => {
   });
 
   it("Should create a new connection object", () => {
-    const conn = new LocalConnection("server:5001", "server1");
+    const conn = new LocalConnection("server:5001", "server1", []);
     conn.disconnect();
     assert.strictEqual(
       conn.connected,

--- a/test/suite/commands.test.ts
+++ b/test/suite/commands.test.ts
@@ -87,7 +87,7 @@ describe("dataSourceCommand", () => {
 
 describe("dataSourceCommand2", () => {
   let dummyDataSourceFiles: DataSourceFiles;
-  const localConn = new LocalConnection("localhost:5001", "test");
+  const localConn = new LocalConnection("localhost:5001", "test", []);
   const insightsNode = new InsightsNode(
     [],
     "insightsnode1",
@@ -1937,7 +1937,7 @@ describe("serverCommand", () => {
       insightsNode.label,
       insightsNode,
     );
-    const localConn = new LocalConnection("localhost:5001", "server1");
+    const localConn = new LocalConnection("localhost:5001", "server1", []);
     beforeEach(() => {
       isVisibleStub = sinon.stub(ext.resultsViewProvider, "isVisible");
       executeQueryStub = sinon.stub(connMangService, "executeQuery");

--- a/test/suite/services.test.ts
+++ b/test/suite/services.test.ts
@@ -1059,7 +1059,7 @@ describe("connectionManagerService", () => {
   );
   ext.serverProvider = new KdbTreeProvider(servers, insights);
 
-  const localConn = new LocalConnection("127.0.0.1:5001", "testLabel");
+  const localConn = new LocalConnection("127.0.0.1:5001", "testLabel", []);
 
   const insightsConn = new InsightsConnection(insightNode.label, insightNode);
   describe("retrieveConnection", () => {
@@ -1322,7 +1322,11 @@ describe("connectionManagerService", () => {
     });
 
     it("disconnectBehaviour", () => {
-      const testConnection = new LocalConnection("localhost:5001", "server1");
+      const testConnection = new LocalConnection(
+        "localhost:5001",
+        "server1",
+        [],
+      );
       ext.connectedConnectionList.push(testConnection);
       ext.activeConnection = testConnection;
 
@@ -2089,7 +2093,7 @@ describe("dataSourceEditorProvider", () => {
         insightsNode.label,
         insightsNode,
       );
-      const localConn = new LocalConnection("127.0.0.1:5001", "testLabel");
+      const localConn = new LocalConnection("127.0.0.1:5001", "testLabel", []);
       const connMngService = new ConnectionManagementService();
       let isConnetedStub, retrieveConnectedConnectionStub: sinon.SinonStub;
       beforeEach(() => {
@@ -2530,7 +2534,7 @@ describe("kdbTreeService", () => {
   });
 
   it("Should return sorted views", async () => {
-    ext.activeConnection = new LocalConnection("localhost:5001", "server1");
+    ext.activeConnection = new LocalConnection("localhost:5001", "server1", []);
     sinon.stub(ext.activeConnection, "executeQuery").resolves(["vw1", "vw2"]);
     const result = await KdbTreeService.loadViews();
     assert.strictEqual(result[0], "vw1", "Should return the first view");
@@ -2538,7 +2542,7 @@ describe("kdbTreeService", () => {
   });
 
   it("Should return sorted views (reverse order)", async () => {
-    ext.activeConnection = new LocalConnection("localhost:5001", "server1");
+    ext.activeConnection = new LocalConnection("localhost:5001", "server1", []);
     sinon.stub(ext.activeConnection, "executeQuery").resolves(["vw1", "vw2"]);
     const result = await KdbTreeService.loadViews();
     assert.strictEqual(result[0], "vw1", "Should return the first view");

--- a/test/suite/utils.test.ts
+++ b/test/suite/utils.test.ts
@@ -221,7 +221,7 @@ describe("Utils", () => {
     });
 
     describe("getServerIconState", () => {
-      const localConn = new LocalConnection("127.0.0.1:5001", "testLabel");
+      const localConn = new LocalConnection("127.0.0.1:5001", "testLabel", []);
       afterEach(() => {
         ext.activeConnection = undefined;
         ext.connectedConnectionList.length = 0;
@@ -248,7 +248,7 @@ describe("Utils", () => {
     });
 
     describe("getStatus", () => {
-      const localConn = new LocalConnection("127.0.0.1:5001", "testLabel");
+      const localConn = new LocalConnection("127.0.0.1:5001", "testLabel", []);
 
       afterEach(() => {
         ext.activeConnection = undefined;
@@ -276,7 +276,7 @@ describe("Utils", () => {
     });
 
     describe("getWorkspaceIconsState", () => {
-      const localConn = new LocalConnection("127.0.0.1:5001", "testLabel");
+      const localConn = new LocalConnection("127.0.0.1:5001", "testLabel", []);
       afterEach(() => {
         ext.connectedConnectionList.length = 0;
       });


### PR DESCRIPTION
### Changes introduced by this PR

- Pass connection labels to custom auth
- Renamed connection label to name
- Auth sample extension changes https://github.com/KxSystems/kx-vscode-auth/commit/f52a0cf2fe30cbdc9e8f43a686c54871a136f794
