### PR TITLE
Fix for connection rename case sensitivity

### DIFF
--- a/src/validators/kdbValidator.ts
+++ b/src/validators/kdbValidator.ts
@@ -107,7 +107,5 @@ export function validateTls(input: string | undefined): string | undefined {
 }
 
 export function isAliasInUse(alias: string): boolean {
-  return !!ext.kdbConnectionAliasList.find(
-    (item) => item.toLowerCase() === alias.toLowerCase(),
-  );
+  return !!ext.kdbConnectionAliasList.find((item) => item === alias);
 }


### PR DESCRIPTION
### Changes introduced by this PR

- Changing case for connection labels works.
