### PR TITLE
Change naming convention for workflows and split out dev workflow

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,11 +1,11 @@
 # This workflow runs the tests across Linux, Mac, Windows
 
-name: KX VScode CI Main Testing
+name: KX VScode CI Dev Testing
 
 on:
   pull_request:
     branches:
-      - main
+      - dev
     paths-ignore: ["**/*.md"]
 
 jobs:

--- a/.github/workflows/prod_release.yml
+++ b/.github/workflows/prod_release.yml
@@ -1,4 +1,4 @@
-name: KX VS Code Production Release Workflow
+name: KX VScode Production Release Workflow
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: KX VS Code Release Workflow
+name: KX VScode Release Workflow
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kdb Visual Studio Code extension
 
-[![KX VS Code CI Testing](https://github.com/KxSystems/kx-vscode/actions/workflows/main.yml/badge.svg)](https://github.com/KxSystems/kx-vscode/actions/workflows/main.yml) [![KX VS Code Release](https://github.com/KxSystems/kx-vscode/actions/workflows/release.yml/badge.svg)](https://github.com/KxSystems/kx-vscode/actions/workflows/release.yml)
+[![KX VScode CI Main Testing](https://github.com/KxSystems/kx-vscode/actions/workflows/main.yml/badge.svg)](https://github.com/KxSystems/kx-vscode/actions/workflows/main.yml) [![KX VScode Release](https://github.com/KxSystems/kx-vscode/actions/workflows/release.yml/badge.svg)](https://github.com/KxSystems/kx-vscode/actions/workflows/release.yml)
 
 The **kdb Visual Studio Code extension** provides developers with an extensive set of features that enables them to create and edit q files, connect to multiple kdb processes, and execute queries.
 


### PR DESCRIPTION
This change will avoid the failing status of workflows appearing on the marketplace

-
