### PR TITLE
fix: Unable to Populate Scratchpad on VSCode

### DIFF
--- a/src/classes/insightsConnection.ts
+++ b/src/classes/insightsConnection.ts
@@ -43,7 +43,11 @@ import {
   tokenUndefinedError,
 } from "../utils/core";
 import { convertTimeToTimestamp } from "../utils/dataSource";
-import { handleScratchpadTableRes, handleWSResults } from "../utils/queryUtils";
+import {
+  generateQSqlBody,
+  handleScratchpadTableRes,
+  handleWSResults,
+} from "../utils/queryUtils";
 import { Telemetry } from "../utils/telemetryClient";
 import { retrieveUDAtoCreateReqBody } from "../utils/uda";
 
@@ -451,11 +455,17 @@ export class InsightsConnection {
         case DataSourceTypes.QSQL: {
           const assemblyParts =
             params.dataSource.qsql.selectedTarget.split(" ");
-          body.params = {
-            assembly: assemblyParts[0],
-            target: assemblyParts[1],
-            query: params.dataSource.qsql.query,
-          };
+          const query = params.dataSource.qsql.query;
+
+          body.params = generateQSqlBody(
+            {
+              assembly: assemblyParts[0],
+              query,
+              target: assemblyParts[1],
+            },
+            this.insightsVersion,
+          );
+
           coreUrl = this.connEndpoints.scratchpad.importQsql;
           dsTypeString = "QSQL";
           break;

--- a/src/commands/dataSourceCommand.ts
+++ b/src/commands/dataSourceCommand.ts
@@ -46,6 +46,7 @@ import {
 } from "../utils/dataSource";
 import {
   addQueryHistory,
+  generateQSqlBody,
   handleScratchpadTableRes,
   handleWSError,
   handleWSResults,
@@ -409,11 +410,17 @@ export async function runQsqlDataSource(
 ): Promise<any> {
   const assembly = fileContent.dataSource.qsql.selectedTarget.slice(0, -4);
   const target = fileContent.dataSource.qsql.selectedTarget.slice(-3);
-  const qsqlBody = {
-    assembly: assembly,
-    target: target,
-    query: fileContent.dataSource.qsql.query,
-  };
+  const query = fileContent.dataSource.qsql.query;
+
+  const qsqlBody = generateQSqlBody(
+    {
+      assembly,
+      query,
+      target,
+    },
+    selectedConn.insightsVersion,
+  );
+
   const qsqlCall = await selectedConn.getDatasourceQuery(
     DataSourceTypes.QSQL,
     JSON.stringify(qsqlBody),

--- a/src/utils/queryUtils.ts
+++ b/src/utils/queryUtils.ts
@@ -15,7 +15,7 @@ import { readFileSync } from "fs";
 import { join } from "path";
 
 import { ext } from "../extensionVariables";
-import { kdbOutputLog } from "./core";
+import { isBaseVersionGreaterOrEqual, kdbOutputLog } from "./core";
 import { DCDS, deserialize, isCompressed, uncompress } from "../ipc/c";
 import { DDateClass, DDateTimeClass, DTimestampClass } from "../ipc/cClasses";
 import { Parse } from "../ipc/parse.qlist";
@@ -204,6 +204,32 @@ export function getValueFromArray(results: DCDS): any {
   }
   results.meta = generateQTypes(results.meta);
   return results;
+}
+
+export function generateQSqlBody(
+  {
+    assembly,
+    query,
+    target,
+  }: { assembly: string; query: string; target: string },
+  version?: number,
+) {
+  if (version && isBaseVersionGreaterOrEqual(version, 1.13)) {
+    return {
+      query,
+      scope: {
+        affinity: "soft",
+        assembly,
+        tier: target,
+      },
+    };
+  }
+
+  return {
+    query,
+    assembly,
+    target,
+  };
 }
 
 export function generateQTypes(meta: { [key: string]: number }): any {

--- a/test/suite/utils.test.ts
+++ b/test/suite/utils.test.ts
@@ -1082,6 +1082,29 @@ describe("Utils", () => {
       });
     });
 
+    describe("generateQSqlBody", () => {
+      let config;
+      beforeEach(() => {
+        config = {
+          assembly: "test-asm",
+          query: "test-query",
+          target: "test-target",
+        };
+      });
+
+      it("should use scope for 1.13", () => {
+        const output = queryUtils.generateQSqlBody(config, 1.13);
+        assert.equal(output.scope.assembly, config.assembly);
+        assert.equal(output.scope.tier, config.target);
+      });
+
+      it("should use legacy syntax for 1.12", () => {
+        const output = queryUtils.generateQSqlBody(config, 1.12);
+        assert.equal(output.assembly, config.assembly);
+        assert.equal(output.target, config.target);
+      });
+    });
+
     describe("handleWSResults", () => {
       afterEach(() => {
         sinon.restore();


### PR DESCRIPTION
### Changes introduced by this PR

- adds a generateQSqlBody utility
- updates Run and Populate Scratchpad in datasources to use utility
