### PR TITLE
KXI-61984 Scratchpad gets deprecation warning for using deprecated sampling set function 

### DIFF
--- a/resources/evaluatePy.q
+++ b/resources/evaluatePy.q
@@ -234,6 +234,10 @@
                 return data.sample(n=sample_size)
             elif isinstance(data, np.ndarray):
                 return np.random.choice(data, sample_size, replace=False)
+            elif isinstance(data, set):
+                return set(sample(list(data),sample_size))
+            elif isinstance(data, frozenset):
+                return frozenset(sample(list(data),sample_size))
             elif isinstance(data, dict):
                 return dict(sample(list(data.items()), sample_size))
             else:


### PR DESCRIPTION
### Changes introduced by this PR

Summary
- Sampling from sets is now no longer deprecated and uses a explicit case to handle sampling functions

Changes
- Fixed a bug where sampling from a set or frozen set would not work in later versions of python.

Testing
- Updated unit test in scratchpad for doing samples on sets and frozen sets