### PR TITLE
[fix] Python error output is not displayed on IE

### DIFF
--- a/src/commands/serverCommand.ts
+++ b/src/commands/serverCommand.ts
@@ -1306,7 +1306,11 @@ export async function writeScratchpadResult(
 
     if (result.stacktrace) {
       errorMsg =
-        errorMsg + "\n" + formatScratchpadStacktrace(result.stacktrace);
+        errorMsg +
+        "\n" +
+        (Array.isArray(result.stacktrace)
+          ? formatScratchpadStacktrace(result.stacktrace)
+          : `${result.stacktrace}`);
     }
   }
 


### PR DESCRIPTION
### Changes introduced by this PR

- Check for scratchpad stacktrace return type.
