### PR TITLE
[fix] Downgrade engine version to 1.96.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@types/node-fetch": "^2.6.12",
         "@types/semver": "^7.7.0",
         "@types/sinon": "^17.0.4",
-        "@types/vscode": "^1.97.2",
+        "@types/vscode": "^1.96.0",
         "@types/vscode-notebook-renderer": "^1.72.3",
         "@types/vscode-webview": "^1.57.5",
         "@typescript-eslint/eslint-plugin": "^8.34.1",
@@ -82,7 +82,7 @@
         "vscode-test": "^1.6.1"
       },
       "engines": {
-        "vscode": "^1.97.2"
+        "vscode": "^1.96.0"
       }
     },
     "node_modules/@ag-grid-community/core": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "publisher": "KX",
   "version": "1.12.0-rc",
   "engines": {
-    "vscode": "^1.97.2"
+    "vscode": "^1.96.0"
   },
   "icon": "resources/images/kx-logo-vs.png",
   "repository": {
@@ -1113,7 +1113,7 @@
     "@types/node-fetch": "^2.6.12",
     "@types/semver": "^7.7.0",
     "@types/sinon": "^17.0.4",
-    "@types/vscode": "^1.97.2",
+    "@types/vscode": "^1.96.0",
     "@types/vscode-notebook-renderer": "^1.72.3",
     "@types/vscode-webview": "^1.57.5",
     "@typescript-eslint/eslint-plugin": "^8.34.1",


### PR DESCRIPTION
### Changes introduced by this PR

- Min required version of VS Code is 1.96.0
