### PR TITLE
Python execution support in DAP

### DIFF
--- a/package.json
+++ b/package.json
@@ -579,7 +579,7 @@
         "command": "kdb.file.populateScratchpad",
         "key": "alt+ctrl+shift+p",
         "mac": "alt+cmd+shift+p",
-        "when": "resourceFilename =~ /\\.(?:q|sql)$/i"
+        "when": "resourceFilename =~ /\\.(?:q|py|sql)$/i"
       },
       {
         "command": "kdb.execute.terminal.run",
@@ -1016,7 +1016,7 @@
         {
           "command": "kdb.file.populateScratchpad",
           "group": "q2@0",
-          "when": "resourceFilename =~ /\\.(?:q|sql)$/i"
+          "when": "resourceFilename =~ /\\.(?:q|py|sql)$/i"
         }
       ],
       "editor/context": [
@@ -1038,7 +1038,7 @@
         {
           "command": "kdb.file.populateScratchpad",
           "group": "q2@0",
-          "when": "resourceFilename =~ /\\.(?:q|sql)$/i"
+          "when": "resourceFilename =~ /\\.(?:q|py|sql)$/i"
         },
         {
           "command": "kdb.scratchpad.python.run.file",

--- a/src/classes/insightsConnection.ts
+++ b/src/classes/insightsConnection.ts
@@ -218,7 +218,7 @@ export class InsightsConnection {
 
       notify("REST", MessageKind.DEBUG, {
         logger,
-        params: { url: metaUrl.toString(), data: options.data },
+        params: { url: metaUrl.toString() },
       });
 
       const metaResponse = await axios.post(metaUrl.toString(), {}, options);
@@ -252,7 +252,7 @@ export class InsightsConnection {
 
       notify("REST", MessageKind.DEBUG, {
         logger,
-        params: { url: options.url, data: options.data },
+        params: { url: options.url },
       });
 
       const configResponse = await axios(options);
@@ -280,7 +280,7 @@ export class InsightsConnection {
 
       notify("REST", MessageKind.DEBUG, {
         logger,
-        params: { url: options.url, data: options.data },
+        params: { url: options.url },
       });
 
       const configResponse = await axios(options);
@@ -414,7 +414,7 @@ export class InsightsConnection {
 
       notify("REST", MessageKind.DEBUG, {
         logger,
-        params: { url: options.url, data: options.data },
+        params: { url: options.url },
       });
 
       return await axios(options)
@@ -531,7 +531,7 @@ export class InsightsConnection {
 
       notify("REST", MessageKind.DEBUG, {
         logger,
-        params: { url: options.url, data: options.data },
+        params: { url: options.url },
       });
 
       return await axios(options).then((response: any) => {
@@ -541,7 +541,7 @@ export class InsightsConnection {
             silent ? MessageKind.DEBUG : MessageKind.ERROR,
             {
               logger,
-              params: response.data.errorMsg,
+              params: { status: response.status },
               telemetry:
                 "Datasource." + dsTypeString + ".Scratchpad.Populated.Errored",
             },
@@ -552,7 +552,7 @@ export class InsightsConnection {
             silent ? MessageKind.DEBUG : MessageKind.INFO,
             {
               logger,
-              params: { status: response.status, params: body.params },
+              params: { status: response.status },
               telemetry: "Datasource." + dsTypeString + ".Scratchpad.Populated",
             },
           );
@@ -617,7 +617,7 @@ export class InsightsConnection {
 
       notify("REST", MessageKind.DEBUG, {
         logger,
-        params: { url: options.url, data: options.data },
+        params: { url: options.url },
       });
 
       return await axios(options).then((response: any) => {
@@ -692,7 +692,7 @@ export class InsightsConnection {
 
       notify("REST", MessageKind.DEBUG, {
         logger,
-        params: { url: options.url, data: options.data },
+        params: { url: options.url },
       });
 
       return await axios(options).then((response: any) => {
@@ -761,7 +761,7 @@ export class InsightsConnection {
 
       notify("REST", MessageKind.DEBUG, {
         logger,
-        params: { url: options.url, data: options.data },
+        params: { url: options.url },
       });
 
       return await axios(options)

--- a/src/commands/dataSourceCommand.ts
+++ b/src/commands/dataSourceCommand.ts
@@ -44,6 +44,7 @@ import { MessageKind, notify } from "../utils/notifications";
 import {
   addQueryHistory,
   generateQSqlBody,
+  getQSQLWrapper,
   handleScratchpadTableRes,
   handleWSError,
   handleWSResults,
@@ -534,6 +535,7 @@ export function getPartialDatasourceFile(
   query: string,
   selectedTarget?: string,
   isSql?: boolean,
+  isPython?: boolean,
 ) {
   return isSql
     ? <DataSourceFiles>{
@@ -545,7 +547,7 @@ export function getPartialDatasourceFile(
     : <DataSourceFiles>{
         dataSource: {
           selectedType: "QSQL",
-          qsql: { query, selectedTarget },
+          qsql: { query: getQSQLWrapper(query, isPython), selectedTarget },
         },
       };
 }

--- a/src/commands/serverCommand.ts
+++ b/src/commands/serverCommand.ts
@@ -1085,6 +1085,9 @@ export async function runQuery(
   }
 
   if (type === ExecutionTypes.PopulateScratchpad) {
+    if (executorName.endsWith(".py")) {
+      isPython = true;
+    }
     variable = await inputVariable();
   }
 
@@ -1092,12 +1095,12 @@ export async function runQuery(
     return target || isSql
       ? variable
         ? populateScratchpad(
-            getPartialDatasourceFile(query, target, isSql),
+            getPartialDatasourceFile(query, target, isSql, isPython),
             connLabel,
             variable,
           )
         : runDataSource(
-            getPartialDatasourceFile(query, target, isSql),
+            getPartialDatasourceFile(query, target, isSql, isPython),
             connLabel,
             executorName,
           )

--- a/src/services/notebookController.ts
+++ b/src/services/notebookController.ts
@@ -198,13 +198,12 @@ export class KxNotebookController {
     kind: CellKind,
     isInsights: boolean,
   ): { target?: string; variable?: string } {
-    const target =
-      isInsights && kind == CellKind.Q ? cell.metadata?.target : undefined;
+    let target, variable: string | undefined;
 
-    const variable =
-      isInsights && (target || kind === CellKind.SQL)
-        ? cell.metadata?.variable
-        : undefined;
+    if (isInsights && (kind === CellKind.Q || kind === CellKind.PYTHON)) {
+      target = cell.metadata?.target;
+      variable = cell.metadata?.variable;
+    }
 
     return { target, variable };
   }
@@ -224,6 +223,7 @@ export class KxNotebookController {
         cell.document.getText(),
         target,
         kind === CellKind.SQL,
+        kind === CellKind.PYTHON,
       );
       return variable
         ? populateScratchpad(params, conn.connLabel, variable, true)

--- a/src/services/notebookProviders.ts
+++ b/src/services/notebookProviders.ts
@@ -53,9 +53,9 @@ export class KxNotebookTargetActionProvider
 
     const actions: vscode.NotebookCellStatusBarItem[] = [];
     const kind = getCellKind(cell);
-    const target = kind === CellKind.Q ? cell.metadata?.target : undefined;
+    const target = cell.metadata?.target;
 
-    if (kind === CellKind.Q) {
+    if (kind === CellKind.Q || kind === CellKind.PYTHON) {
       const targetItem = new vscode.NotebookCellStatusBarItem(
         target || "scratchpad",
         vscode.NotebookCellStatusBarAlignment.Right,

--- a/test/suite/commands.test.ts
+++ b/test/suite/commands.test.ts
@@ -3089,4 +3089,19 @@ describe("clientCommands", () => {
       assert.strictEqual(edit.size, 1);
     });
   });
+
+  describe("getPartialDatasourceFile", () => {
+    it("should return qsql datatsource", () => {
+      const res = dataSourceCommand.getPartialDatasourceFile("query");
+      assert.strictEqual(res.dataSource.selectedType, "QSQL");
+    });
+    it("should return sql datatsource", () => {
+      const res = dataSourceCommand.getPartialDatasourceFile(
+        "query",
+        "dap",
+        true,
+      );
+      assert.strictEqual(res.dataSource.selectedType, "SQL");
+    });
+  });
 });

--- a/test/suite/notebooks.test.ts
+++ b/test/suite/notebooks.test.ts
@@ -574,10 +574,10 @@ describe("Notebooks", () => {
             assert.strictEqual(res.length, 0);
           });
 
-          it("should return none for python", async () => {
+          it("should return target for python", async () => {
             const cell = createCell("python");
             const res = await instance.provideCellStatusBarItems(cell, token);
-            assert.strictEqual(res.length, 0);
+            assert.strictEqual(res.length, 1);
           });
         });
       });

--- a/test/suite/utils.test.ts
+++ b/test/suite/utils.test.ts
@@ -2187,6 +2187,31 @@ describe("Utils", () => {
         assert.throws(() => queryUtils.normalizeQuery(query));
       });
     });
+
+    describe("normalizePyQuery", () => {
+      it("should escape double quotes", () => {
+        const res = queryUtils.normalizePyQuery('a="test"');
+        assert.strictEqual(res, 'a=\\"test\\"');
+      });
+    });
+    describe("getQSQLWrapper", () => {
+      let queryWrappeStub: sinon.SinonStub;
+
+      beforeEach(() => {
+        //queryWrappeStub = sinon.stub(queryUtils, "queryWrapper");
+      });
+
+      it("should normalize q code", () => {
+        const res = queryUtils.getQSQLWrapper("a:1;\na");
+        assert.strictEqual(res, "a:1;;a");
+      });
+      it("should normalize python code using wrapper", () => {
+        assert.throws(() => {
+          queryUtils.getQSQLWrapper(``, true);
+          sinon.assert.calledOnce(queryWrappeStub);
+        });
+      });
+    });
   });
 
   describe("Registration", () => {

--- a/test/suite/utils.test.ts
+++ b/test/suite/utils.test.ts
@@ -2065,41 +2065,41 @@ describe("Utils", () => {
       });
     });
 
-    describe("sanitizeQsqlQuery", () => {
+    describe("normalizeQSQLQuery", () => {
       it("should trim query", () => {
-        const res = queryUtils.sanitizeQsqlQuery("  a:1  ");
+        const res = queryUtils.normalizeQSQLQuery("  a:1  ");
         assert.strictEqual(res, "a:1");
       });
       it("should remove block comment", () => {
-        let res = queryUtils.sanitizeQsqlQuery("/\nBlock Comment\n\\\na:1");
+        let res = queryUtils.normalizeQSQLQuery("/\nBlock Comment\n\\\na:1");
         assert.strictEqual(res, "a:1");
-        res = queryUtils.sanitizeQsqlQuery("/\r\nBlock Comment\r\n\\\r\na:1");
+        res = queryUtils.normalizeQSQLQuery("/\r\nBlock Comment\r\n\\\r\na:1");
         assert.strictEqual(res, "a:1");
       });
       it("should remove single line comment", () => {
-        let res = queryUtils.sanitizeQsqlQuery("/ single line comment\na:1");
+        let res = queryUtils.normalizeQSQLQuery("/ single line comment\na:1");
         assert.strictEqual(res, "a:1");
-        res = queryUtils.sanitizeQsqlQuery("/ single line comment\r\na:1");
+        res = queryUtils.normalizeQSQLQuery("/ single line comment\r\na:1");
         assert.strictEqual(res, "a:1");
       });
       it("should remove line comment", () => {
-        const res = queryUtils.sanitizeQsqlQuery("a:1 / line comment");
+        const res = queryUtils.normalizeQSQLQuery("a:1 / line comment");
         assert.strictEqual(res, "a:1");
       });
       it("should ignore line comment in a string", () => {
-        const res = queryUtils.sanitizeQsqlQuery('a:"1 / not line comment"');
+        const res = queryUtils.normalizeQSQLQuery('a:"1 / not line comment"');
         assert.strictEqual(res, 'a:"1 / not line comment"');
       });
       it("should replace EOS with semicolon", () => {
-        let res = queryUtils.sanitizeQsqlQuery("a:1\na");
+        let res = queryUtils.normalizeQSQLQuery("a:1\na");
         assert.strictEqual(res, "a:1;a");
-        res = queryUtils.sanitizeQsqlQuery("a:1\r\na");
+        res = queryUtils.normalizeQSQLQuery("a:1\r\na");
         assert.strictEqual(res, "a:1;a");
       });
       it("should escpae new lines in strings", () => {
-        let res = queryUtils.sanitizeQsqlQuery('a:"a\n \nb"');
+        let res = queryUtils.normalizeQSQLQuery('a:"a\n \nb"');
         assert.strictEqual(res, 'a:"a\\n \\nb"');
-        res = queryUtils.sanitizeQsqlQuery('a:"a\r\n \r\nb"');
+        res = queryUtils.normalizeQSQLQuery('a:"a\r\n \r\nb"');
         assert.strictEqual(res, 'a:"a\\n \\nb"');
       });
     });
@@ -2182,10 +2182,9 @@ describe("Utils", () => {
         const res = queryUtils.normalizeQuery(query);
         assert.strictEqual(res, query);
       });
-      it("should return empty query when limit reached", () => {
+      it("should throw when limit reached", () => {
         const query = "1234567890".repeat(25000) + "1";
-        const res = queryUtils.normalizeQuery(query);
-        assert.strictEqual(res, "");
+        assert.throws(() => queryUtils.normalizeQuery(query));
       });
     });
   });


### PR DESCRIPTION
### Changes introduced by this PR

- Python execution support for `.py` files in DAP.
- Python populate scratchpad support for `.py` files in DAP.
- Support added for Python blocks in KX Notebooks as well.
