### PR TITLE
[REPL] Added workspace picker for multi root

### DIFF
--- a/src/classes/replConnection.ts
+++ b/src/classes/replConnection.ts
@@ -31,6 +31,7 @@ import {
 } from "../utils/notifications";
 import { normalizeQuery } from "../utils/queryUtils";
 import { errorMessage } from "../utils/shared";
+import { pickWorkspace } from "../utils/workspace";
 
 const logger = "replConnection";
 
@@ -738,8 +739,7 @@ export class ReplConnection {
   static async getOrCreateInstance(resource?: vscode.Uri) {
     const workspace =
       (resource && vscode.workspace.getWorkspaceFolder(resource)) ||
-      (vscode.workspace.workspaceFolders &&
-        vscode.workspace.workspaceFolders[0]);
+      (await pickWorkspace());
 
     const key = workspace?.uri.toString() ?? CONF.DEFAULT;
 

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -138,3 +138,19 @@ export async function getWorkbookStatistics(
   }
   throw new Error("No workspace has been opened");
 }
+
+export async function pickWorkspace() {
+  const folders = workspace.workspaceFolders;
+  if (!folders || folders.length === 0) return undefined;
+  if (folders.length === 1) return folders[0];
+  const picked = await window.showQuickPick(
+    folders.map((folder) => ({
+      folder,
+      label: folder.name,
+      description: folder.uri.path,
+    })),
+    { placeHolder: "Select workspace directory" },
+  );
+  if (!picked) return folders[0];
+  return picked.folder;
+}

--- a/test/suite/utils/workspace.test.ts
+++ b/test/suite/utils/workspace.test.ts
@@ -119,4 +119,49 @@ describe("Workspace tests", () => {
       assert.strictEqual(executeCommand.calledOnce, true);
     });
   });
+
+  describe("pickWorkspace", () => {
+    let showQuickPickStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      showQuickPickStub = sinon.stub(vscode.window, "showQuickPick");
+    });
+
+    afterEach(() => {
+      showQuickPickStub.restore();
+    });
+
+    it("should return undefined for no workspace folders", async () => {
+      workspaceMock.value(undefined);
+      const res = await workspaceHelper.pickWorkspace();
+      assert.strictEqual(res, undefined);
+    });
+
+    it("should return undefined for empty workspace folders", async () => {
+      workspaceMock.value([]);
+      const res = await workspaceHelper.pickWorkspace();
+      assert.strictEqual(res, undefined);
+    });
+
+    it("should return the picked folder", async () => {
+      const folder = {};
+      workspaceMock.value([folder]);
+      const res = await workspaceHelper.pickWorkspace();
+      assert.strictEqual(res, folder);
+    });
+
+    it("should return the picked folder", async () => {
+      workspaceMock.value(testWorkspaceFolder);
+      showQuickPickStub.resolves(<any>{ folder: testWorkspaceFolder[1] });
+      const res = await workspaceHelper.pickWorkspace();
+      assert.strictEqual(res, testWorkspaceFolder[1]);
+    });
+
+    it("should return first workspace when cancelled", async () => {
+      workspaceMock.value(testWorkspaceFolder);
+      showQuickPickStub.resolves(undefined);
+      const res = await workspaceHelper.pickWorkspace();
+      assert.strictEqual(res, testWorkspaceFolder[0]);
+    });
+  });
 });


### PR DESCRIPTION
### Changes introduced by this PR

- Added workspace picker for multi root workspaces to the REPL.

<img width="603" height="86" alt="image" src="https://github.com/user-attachments/assets/75339d8b-6bed-4e42-ab7e-bba89466fc80" />
