### PR TITLE
Always double quote CSV export

### DIFF
--- a/src/utils/resultsRenderer.ts
+++ b/src/utils/resultsRenderer.ts
@@ -245,13 +245,14 @@ export function formatResult(queryResult: string | number): string {
 
 export function convertToCsv(data: any[]): string[] {
   const keys = Object.keys(data[0]);
-  const header = keys.join(",");
-  const rows = data.map((obj) => {
-    return keys
-      .map((key) => {
-        return obj[key];
-      })
-      .join(",");
-  });
+  const header = keys.map((k) => normalize(k)).join(",");
+  const rows = data.map((obj) =>
+    keys.map((key) => normalize(obj[key])).join(","),
+  );
   return [header, ...rows];
+}
+
+function normalize(obj: any) {
+  const o = `${obj}`;
+  return `"${o.replace(/"/gs, '""')}"`;
 }

--- a/test/suite/webPanels/resultsPanelProvider.test.ts
+++ b/test/suite/webPanels/resultsPanelProvider.test.ts
@@ -375,7 +375,7 @@ describe("ResultsPanelProvider", () => {
         { a: "2", b: "2" },
         { a: "3", b: "3" },
       ];
-      const expectedOutput = ["a,b", "1,1", "2,2", "3,3"];
+      const expectedOutput = ['"a","b"', '"1","1"', '"2","2"', '"3","3"'];
       const actualOutput = renderer.convertToCsv(inputQueryResult);
       assert.deepStrictEqual(actualOutput, expectedOutput);
     });


### PR DESCRIPTION
### Changes introduced by this PR

- Always double quote CSV columns
- Escape actual double quote with `""`
