### PR TITLE
Add timeouts to scratchpad and DB queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,18 @@
           "default": {},
           "scope": "resource"
         },
+        "kdb.timeoutMap": {
+          "type": "object",
+          "description": "Timeout map for workspace files",
+          "default": {},
+          "scope": "resource"
+        },
+        "kdb.defaultTimeout": {
+          "type": "number",
+          "description": "Timeout in seconds for Insights Enterprise requests",
+          "default": 30,
+          "scope": "machine-overridable"
+        },
         "kdb.connectionLabels": {
           "type": "array",
           "description": "List of label names and colorset",

--- a/ref_card.md
+++ b/ref_card.md
@@ -52,6 +52,8 @@
 | [kdb.qHomeDirectoryWorkspace](https://github.com/KxSystems/kx-vscode/wiki/qHomeDirectory) | resource | `string`  | `""`          |
 | kdb.connectionMap                                                                         | resource | `object`  | `{}`          |
 | kdb.targetMap                                                                             | resource | `object`  | `{}`          |
+| kdb.timeoutMap                                                                            | resource | `object`  | `{}`          |
+| kdb.defaultTimeout                                                                        | resource | `number`  | `30`          |
 | kdb.linting                                                                               | resource | `boolean` | `false`       |
 | kdb.refactoring                                                                           | resource | `string`  | `"Workspace"` |
 
@@ -95,6 +97,7 @@
 | Connection.Export.All             |              | src/extension.ts                         |
 | Connection.Export.Single          |              | src/extension.ts                         |
 | Connection.Import                 |              | src/extension.ts                         |
+| Connection.Cancel.ie.sp           |              | src/classes/insightsConnection.ts        |
 | Connection.Reset.ie.sp            |              | src/classes/insightsConnection.ts        |
 | Connection.Label.Create           |      ✓       | src/utils/connLabel.ts                   |
 | Connection.Label.Delete           |      ✓       | src/utils/connLabel.ts                   |

--- a/src/classes/insightsConnection.ts
+++ b/src/classes/insightsConnection.ts
@@ -41,21 +41,15 @@ import {
 } from "../utils/core";
 import { convertTimeToTimestamp } from "../utils/dataSource";
 import { MessageKind, notify } from "../utils/notifications";
-import { handleScratchpadTableRes, handleWSResults } from "../utils/queryUtils";
+import {
+  getHeaders,
+  handleScratchpadTableRes,
+  handleWSResults,
+} from "../utils/queryUtils";
 import { normalizeAssemblyTarget } from "../utils/shared";
 import { retrieveUDAtoCreateReqBody } from "../utils/uda";
 
 const logger = "insightsConnection";
-
-const customHeadersOctet = {
-  Accept: "application/struct-text",
-  "Content-Type": "application/json",
-};
-const customHeadersJson = {
-  "Content-Type": "application/json",
-  Accept: "application/json",
-  json: true,
-};
 
 export class InsightsConnection {
   public connected: boolean;
@@ -295,6 +289,7 @@ export class InsightsConnection {
       importSql: "scratchpadmanager/scratchpad/import/sql",
       importQsql: "scratchpadmanager/scratchpad/import/qsql",
       importUDA: "scratchpadmanager/scratchpad/import/uda",
+      cancel: "scratchpadmanager/scratchpad/cancel",
       reset: "scratchpadmanager/reset",
     };
 
@@ -457,6 +452,7 @@ export class InsightsConnection {
   public async getDatasourceQuery(
     type: DataSourceTypes,
     body: any,
+    timeout?: number,
   ): Promise<GetDataObjectPayload | undefined> {
     if (this.connected) {
       const udaName = (body as UDARequestBody).name
@@ -473,7 +469,7 @@ export class InsightsConnection {
       const requestUrl = this.generateDatasourceEndpoints(type, udaName);
       const options = await this.getOptions(
         false,
-        customHeadersOctet,
+        getHeaders(timeout ? timeout * 1000 : 0, "struct-text"), // DAPs use milliseconds
         "POST",
         requestUrl,
         body,
@@ -518,6 +514,7 @@ export class InsightsConnection {
     variableName: string,
     params: DataSourceFiles,
     silent?: boolean,
+    timeout?: number,
   ): Promise<void> {
     if (this.connected && this.connEndpoints) {
       let coreUrl: string;
@@ -579,7 +576,7 @@ export class InsightsConnection {
       const scratchpadURL = new url.URL(coreUrl!, this.node.details.server);
       const options = await this.getOptions(
         true,
-        customHeadersJson,
+        getHeaders(timeout),
         "POST",
         scratchpadURL.toString(),
         body,
@@ -654,6 +651,7 @@ export class InsightsConnection {
 
   public async getUDAScratchpadQuery(
     udaReqBody: UDARequestBody,
+    timeout?: number,
   ): Promise<any | undefined> {
     if (this.connected && this.connEndpoints) {
       const isTableView = udaReqBody.returnFormat === "structuredText";
@@ -663,7 +661,7 @@ export class InsightsConnection {
       );
       const options = await this.getOptions(
         true,
-        customHeadersJson,
+        getHeaders(timeout),
         "POST",
         udaURL.toString(),
         udaReqBody,
@@ -706,6 +704,7 @@ export class InsightsConnection {
     context?: string,
     isPython?: boolean,
     isTableView?: boolean,
+    timeout?: number,
   ): Promise<any | undefined> {
     if (this.connected && this.connEndpoints) {
       if (isTableView === undefined) {
@@ -733,7 +732,7 @@ export class InsightsConnection {
 
       const options = await this.getOptions(
         true,
-        customHeadersJson,
+        getHeaders(timeout),
         "POST",
         scratchpadURL.toString(),
         body,
@@ -792,6 +791,52 @@ export class InsightsConnection {
     return undefined;
   }
 
+  public async cancelScratchpad(): Promise<boolean | undefined> {
+    if (this.connected && this.connEndpoints) {
+      const scratchpadURL = new url.URL(
+        this.connEndpoints.scratchpad.cancel,
+        this.node.details.server,
+      );
+      const options = await this.getOptions(
+        true,
+        getHeaders(),
+        "POST",
+        scratchpadURL.toString(),
+        undefined,
+      );
+
+      if (!options) {
+        return;
+      }
+
+      notify("REST", MessageKind.DEBUG, {
+        logger,
+        params: { url: options.url },
+      });
+
+      return await axios(options)
+        .then((_response: any) => {
+          notify(
+            `Scratchpad cancel request sent for ${this.connLabel}.`,
+            MessageKind.INFO,
+            { logger, telemetry: "Connection.Cancel.ie.sp" },
+          );
+          return true;
+        })
+        .catch((_error: any) => {
+          notify(
+            `Scratchpad cancel request error: ${_error.response.data.message}`,
+            MessageKind.ERROR,
+            { logger },
+          );
+          return false;
+        });
+    } else {
+      this.noConnectionOrEndpoints();
+      return false;
+    }
+  }
+
   public async resetScratchpad(): Promise<boolean | undefined> {
     if (this.connected && this.connEndpoints) {
       const scratchpadURL = new url.URL(
@@ -800,7 +845,7 @@ export class InsightsConnection {
       );
       const options = await this.getOptions(
         true,
-        customHeadersJson,
+        getHeaders(),
         "POST",
         scratchpadURL.toString(),
         null,

--- a/src/commands/dataSourceCommand.ts
+++ b/src/commands/dataSourceCommand.ts
@@ -86,6 +86,7 @@ export async function populateScratchpad(
   connLabel: string,
   outputVariable?: string,
   silent?: boolean,
+  timeout?: number,
 ): Promise<void> {
   const connMngService = new ConnectionManagementService();
 
@@ -112,6 +113,7 @@ export async function populateScratchpad(
       outputVariable,
       dataSourceForm,
       silent,
+      timeout,
     );
   } else {
     notify(
@@ -126,6 +128,7 @@ export async function runDataSource(
   dataSourceForm: DataSourceFiles,
   connLabel: string,
   executorName: string,
+  timeout?: number,
 ): Promise<any> {
   if (DataSourcesPanel.running) {
     return;
@@ -165,17 +168,18 @@ export async function runDataSource(
 
     switch (selectedType) {
       case "API":
-        res = await runApiDataSource(fileContent, selectedConnection);
+        res = await runApiDataSource(fileContent, selectedConnection, timeout);
         break;
       case "QSQL":
         res = await runQsqlDataSource(
           fileContent,
           selectedConnection,
           isNotebook || undefined,
+          timeout,
         );
         break;
       case "UDA":
-        res = await runUDADataSource(fileContent, selectedConnection);
+        res = await runUDADataSource(fileContent, selectedConnection, timeout);
         break;
       case "SQL":
       default:
@@ -183,6 +187,7 @@ export async function runDataSource(
           fileContent,
           selectedConnection,
           isNotebook || undefined,
+          timeout,
         );
         break;
     }
@@ -300,6 +305,7 @@ export function getSelectedType(fileContent: DataSourceFiles): string {
 export async function runApiDataSource(
   fileContent: DataSourceFiles,
   selectedConn: InsightsConnection,
+  timeout?: number,
 ): Promise<any> {
   const isTimeCorrect = checkIfTimeParamIsCorrect(
     fileContent.dataSource.api.startTS,
@@ -317,6 +323,7 @@ export async function runApiDataSource(
   const apiCall = await selectedConn.getDatasourceQuery(
     DataSourceTypes.API,
     JSON.stringify(apiBody),
+    timeout,
   );
 
   if (apiCall?.error) {
@@ -420,6 +427,7 @@ export async function runQsqlDataSource(
   fileContent: DataSourceFiles,
   selectedConn: InsightsConnection,
   isTableView?: boolean,
+  timeout?: number,
 ): Promise<any> {
   const qsqlBody = selectedConn.generateQSqlBody(
     fileContent.dataSource.qsql.query,
@@ -430,6 +438,7 @@ export async function runQsqlDataSource(
   const qsqlCall = await selectedConn.getDatasourceQuery(
     DataSourceTypes.QSQL,
     JSON.stringify(qsqlBody),
+    timeout,
   );
 
   if (qsqlCall?.error) {
@@ -448,6 +457,7 @@ export async function runSqlDataSource(
   fileContent: DataSourceFiles,
   selectedConn: InsightsConnection,
   isTableView?: boolean,
+  timeout?: number,
 ): Promise<any> {
   const sqlBody = {
     query: fileContent.dataSource.sql.query,
@@ -455,6 +465,7 @@ export async function runSqlDataSource(
   const sqlCall = await selectedConn.getDatasourceQuery(
     DataSourceTypes.SQL,
     JSON.stringify(sqlBody),
+    timeout,
   );
 
   if (sqlCall?.error) {
@@ -472,6 +483,7 @@ export async function runSqlDataSource(
 export async function runUDADataSource(
   fileContent: DataSourceFiles,
   selectedConn: InsightsConnection,
+  timeout?: number,
 ): Promise<any> {
   const uda = fileContent.dataSource.uda;
 
@@ -485,16 +497,18 @@ export async function runUDADataSource(
     return udaReqBody;
   }
 
-  return await executeUDARequest(selectedConn, udaReqBody);
+  return await executeUDARequest(selectedConn, udaReqBody, timeout);
 }
 
 export async function executeUDARequest(
   selectedConn: InsightsConnection,
   udaReqBody: UDARequestBody,
+  timeout?: number,
 ): Promise<any> {
   const udaCall = await selectedConn.getDatasourceQuery(
     DataSourceTypes.UDA,
     udaReqBody,
+    timeout,
   );
 
   if (udaCall?.error) {

--- a/src/commands/serverCommand.ts
+++ b/src/commands/serverCommand.ts
@@ -883,6 +883,7 @@ export async function executeQuery(
   isWorkbook: boolean,
   isFromConnTree?: boolean,
   token?: CancellationToken,
+  timeout?: number,
 ): Promise<any> {
   const connMngService = new ConnectionManagementService();
   const queryConsole = ExecutionConsole.start();
@@ -933,6 +934,7 @@ export async function executeQuery(
     context,
     isStringfy,
     isPython,
+    timeout,
   );
   const endTime = Date.now();
   const duration = (endTime - startTime).toString();
@@ -1078,6 +1080,8 @@ export async function runQuery(
   target?: string,
   isSql?: boolean,
   isInsights?: boolean,
+  timeout?: number,
+  cancel?: () => void,
 ) {
   const editor = ext.activeTextEditor;
   if (!editor) {
@@ -1129,17 +1133,24 @@ export async function runQuery(
   }
 
   const runner = Runner.create((_, token) => {
+    if (cancel) {
+      token.onCancellationRequested(cancel);
+    }
+
     return target || (isSql && isInsights)
       ? variable
         ? populateScratchpad(
             getPartialDatasourceFile(query, target, isSql, isPython),
             connLabel,
             variable,
+            undefined,
+            timeout,
           )
         : runDataSource(
             getPartialDatasourceFile(query, target, isSql, isPython),
             connLabel,
             executorName,
+            timeout,
           )
       : executeQuery(
           query,
@@ -1150,6 +1161,7 @@ export async function runQuery(
           isWorkbook,
           false,
           token,
+          timeout,
         );
   });
 

--- a/src/commands/workspaceCommand.ts
+++ b/src/commands/workspaceCommand.ts
@@ -44,6 +44,8 @@ import { ConnectionManagementService } from "../services/connectionManagerServic
 import { InsightsNode, KdbNode, LabelNode } from "../services/kdbTreeProvider";
 import { updateCellMetadata } from "../services/notebookProviders";
 import {
+  calculateSeconds,
+  formatSeconds,
   getBasename,
   isQuick,
   isQuickAlias,
@@ -86,18 +88,22 @@ function setRealActiveTextEditor(editor?: TextEditor | undefined) {
 function activeEditorChanged(editor?: TextEditor | undefined) {
   /* c8 ignore start */
   setRealActiveTextEditor(editor);
-  const item = ext.runScratchpadItem;
+  const runItem = ext.runScratchpadItem;
+
   if (ext.activeTextEditor) {
     const uri = ext.activeTextEditor.document.uri;
     const server = getServerForUri(uri);
     if (server) {
       setRunScratchpadItemText(uri, server);
-      item.show();
+      runItem.show();
     } else {
-      item.hide();
+      runItem.hide();
     }
+
+    setTimeoutItem(uri);
   } else {
-    item.hide();
+    runItem.hide();
+    ext.pickTimeoutItem.hide();
   }
   /* c8 ignore stop */
 }
@@ -107,6 +113,43 @@ function setRunScratchpadItemText(uri: Uri, text: string) {
   ext.runScratchpadItem.text = `$(cloud) ${text}`;
   ext.runScratchpadItem.tooltip = `KX: Choose connection for '${getBasename(uri)}'`;
   /* c8 ignore stop */
+}
+
+export async function setTimeoutItem(uri: Uri) {
+  const server = getServerForUri(uri);
+  const timeoutItem = ext.pickTimeoutItem;
+
+  if (server) {
+    const conn = await getConnectionForServer(server);
+
+    if (conn instanceof InsightsNode) {
+      const timeout = getTimeoutForUri(uri);
+      setTimeouttemText(uri, timeout);
+      timeoutItem.show();
+    } else {
+      timeoutItem.hide();
+    }
+  } else {
+    timeoutItem.hide();
+  }
+}
+
+function setTimeouttemText(
+  uri: Uri,
+  { source, value }: { source: string; value?: number },
+) {
+  let text = "default";
+
+  if (value) {
+    if (source === "uri") {
+      text = formatSeconds(value);
+    } else if (source === "workspace") {
+      text = `Default (${formatSeconds(value)})`;
+    }
+  }
+
+  ext.pickTimeoutItem.text = `$(watch) ${text}`;
+  ext.pickTimeoutItem.tooltip = `KX: Choose timeout for '${getBasename(uri)}'`;
 }
 
 export function getInsightsServers() {
@@ -237,6 +280,76 @@ export function getTargetForUri(uri: Uri) {
   return target ? normalizeAssemblyTarget(target) : undefined;
 }
 
+export async function setTimeoutForUri(uri: Uri, timeout: number | undefined) {
+  let apply = true;
+  let explainer = "";
+
+  if (timeout) {
+    // info message for unsupported timeout (>7hrs)
+    if (timeout > 25200) {
+      explainer = "the maximum allowed";
+      timeout = 25200;
+    }
+
+    const formatted = formatSeconds(timeout);
+
+    // warning for high timeouts (>20min)
+    if (timeout > 1200) {
+      const highTimeoutPrompt = await notify(
+        `High timeout warning: You have set an execution timeout of ${formatted}${explainer ? " (" + explainer + ")" : ""}. Note that database queries will continue to run on the Data Access Process until completion or timeout, even if a Scratchpad query is cancelled. The DAP will be unavailable for all users while a query is running.`,
+        MessageKind.WARNING,
+        {},
+        "Keep Timeout",
+        "Cancel",
+      );
+
+      if (highTimeoutPrompt === "Cancel") {
+        apply = false;
+      }
+    }
+  }
+
+  if (apply) {
+    uri = Uri.file(uri.path);
+    const conf = workspace.getConfiguration("kdb", uri);
+    const map = conf.get<{ [key: string]: number | undefined }>(
+      "timeoutMap",
+      {},
+    );
+    map[relativePath(uri)] = timeout;
+    await conf.update("timeoutMap", map);
+    setTimeouttemText(uri, { source: "uri", value: timeout });
+  }
+}
+
+export function getTimeoutForUri(uri: Uri) {
+  uri = Uri.file(uri.path);
+  const conf = workspace.getConfiguration("kdb", uri);
+  const map = conf.get<{ [key: string]: number | undefined }>("timeoutMap", {});
+  const uriTimeout = map[relativePath(uri)];
+
+  if (uriTimeout) {
+    return {
+      source: "uri",
+      value: uriTimeout,
+    };
+  }
+
+  const workspaceTimeout = conf.get<number | undefined>("defaultTimeout");
+
+  if (workspaceTimeout) {
+    return {
+      source: "workspace",
+      value: workspaceTimeout,
+    };
+  }
+
+  return {
+    source: "none",
+    value: 30,
+  };
+}
+
 export function getConnectionForUri(uri: Uri) {
   const server = getServerForUri(uri);
   if (server) {
@@ -364,6 +477,56 @@ export async function pickTarget(uri: Uri, cell?: NotebookCell) {
 
   return selectedValue;
   /* c8 ignore stop */
+}
+
+export async function pickTimeout(uri: Uri) {
+  // prompt for unit
+  const unitItems: QuickPickItem[] = [
+    { label: "Seconds", description: "s" },
+    { label: "Minutes", description: "min" },
+    { label: "Hours", description: "hr" },
+    { label: "", kind: QuickPickItemKind.Separator },
+    { label: "Clear", description: "Use default timeout" },
+  ];
+  const selectedUnit = await window.showQuickPick(unitItems, {
+    placeHolder: "Select the timeout unit",
+    canPickMany: false,
+  });
+
+  const timeoutUnit = selectedUnit?.label;
+
+  if (timeoutUnit === "Clear") {
+    await setTimeoutForUri(uri, undefined);
+    const timeout = await getTimeoutForUri(uri);
+    setTimeouttemText(uri, timeout);
+  } else if (timeoutUnit) {
+    // prompt for value
+    const timeoutValue = await window.showInputBox({
+      prompt: `Enter timeout value in ${timeoutUnit.toLowerCase()}`,
+      placeHolder: "e.g. 30",
+      validateInput: (text) => {
+        if (text !== "" && (isNaN(Number(text)) || Number(text) <= 0)) {
+          return "Please enter a positive number";
+        }
+
+        const timeout = calculateSeconds(Number(text), timeoutUnit);
+        if (timeout > 60 * 60 * 7) {
+          return "Please enter a maximum of 7 hours";
+        }
+
+        return null;
+      },
+    });
+
+    if (timeoutValue) {
+      // convert to seconds
+      const timeout = calculateSeconds(Number(timeoutValue), timeoutUnit);
+
+      if (timeout) {
+        await setTimeoutForUri(uri, timeout);
+      }
+    }
+  }
 }
 
 function createTierKey(dap: MetaDap): string {
@@ -621,6 +784,7 @@ export async function runActiveEditor(type?: ExecutionTypes) {
     const isInsights = conn instanceof InsightsConnection;
     const executorName = getBasename(ext.activeTextEditor.document.uri);
     const target = isInsights ? getTargetForUri(uri) : undefined;
+    const timeout = isInsights ? getTimeoutForUri(uri).value : undefined;
 
     if (type === ExecutionTypes.PopulateScratchpad && !isInsights) {
       notify(
@@ -645,6 +809,12 @@ export async function runActiveEditor(type?: ExecutionTypes) {
         target,
         !!isSql(uri),
         isInsights,
+        timeout,
+        () => {
+          if (isInsights && !target) {
+            conn.cancelScratchpad();
+          }
+        },
       );
       notifyExecution(
         (type === ExecutionTypes.PopulateScratchpad ? 0 : RunFlag.Run) |
@@ -731,6 +901,16 @@ export function connectWorkspaceCommands() {
     arguments: [],
   };
 
+  ext.pickTimeoutItem = window.createStatusBarItem(
+    StatusBarAlignment.Right,
+    10000,
+  );
+  ext.pickTimeoutItem.command = <Command>{
+    title: "Choose Timeout",
+    command: "kdb.file.pickTimeout",
+    arguments: [],
+  };
+
   const watcher = workspace.createFileSystemWatcher("**/*.{kdb.json,q,py,sql}");
   watcher.onDidCreate(update);
   watcher.onDidDelete(update);
@@ -754,6 +934,12 @@ export function connectWorkspaceCommands() {
       await setServerForUri(oldUri, undefined);
       await setTargetForUri(newUri, getTargetForUri(oldUri));
       await setTargetForUri(oldUri, undefined);
+
+      const timeout = getTimeoutForUri(oldUri);
+      if (timeout.source === "uri") {
+        await setTimeoutForUri(newUri, timeout.value);
+        await setTimeoutForUri(oldUri, undefined);
+      }
     }
     /* c8 ignore stop */
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,6 +52,7 @@ import {
   importOldDSFiles,
   pickConnection,
   pickTarget,
+  pickTimeout,
   resetScratchpadFromEditor,
   runActiveEditor,
   setServerForUri,
@@ -928,6 +929,15 @@ function registerFileCommands(): CommandRegistration[] {
         const editor = ext.activeTextEditor;
         if (editor) {
           await pickTarget(editor.document.uri, cell);
+        }
+      },
+    },
+    {
+      command: "kdb.file.pickTimeout",
+      callback: async () => {
+        const editor = ext.activeTextEditor;
+        if (editor) {
+          await pickTimeout(editor.document.uri);
         }
       },
     },

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -59,6 +59,7 @@ export namespace ext {
   export let scratchpadTreeProvider: WorkspaceTreeProvider;
   export let dataSourceTreeProvider: WorkspaceTreeProvider;
   export let runScratchpadItem: StatusBarItem;
+  export let pickTimeoutItem: StatusBarItem;
   export const activeScratchPadList: Array<ScratchpadFile> = [];
   export const connectedScratchPadList: Array<ScratchpadFile> = [];
   export const activeDatasourceList: Array<DataSourceFiles> = [];

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -34,6 +34,7 @@ export type InsightsEndpoints = {
     importSql: string;
     importQsql: string;
     importUDA: string;
+    cancel: string;
     reset: string;
   };
   serviceGateway: {

--- a/src/models/messages.ts
+++ b/src/models/messages.ts
@@ -31,6 +31,7 @@ export const enum DataSourceCommand {
   Update,
   Change,
   Server,
+  Timeout,
   Save,
   Run,
   Populate,
@@ -39,6 +40,9 @@ export const enum DataSourceCommand {
 
 export interface DataSourceMessage2 {
   command: DataSourceCommand;
+  timeoutDefault: boolean;
+  timeoutUnit: string;
+  timeoutValue: number;
   servers: string[];
   selectedServer: string;
   selectedServerVersion: number;

--- a/src/services/connectionManagerService.ts
+++ b/src/services/connectionManagerService.ts
@@ -320,6 +320,7 @@ export class ConnectionManagementService {
     context?: string,
     stringify?: boolean,
     isPython?: boolean,
+    timeout?: number,
   ): Promise<any> {
     let selectedConn;
     if (connLabel) {
@@ -347,6 +348,7 @@ export class ConnectionManagementService {
         context,
         isPython,
         !stringify,
+        timeout,
       );
     }
   }

--- a/src/services/dataSourceEditorProvider.ts
+++ b/src/services/dataSourceEditorProvider.ts
@@ -38,12 +38,19 @@ import {
   getConnectionForServer,
   getInsightsServers,
   getServerForUri,
+  getTimeoutForUri,
   setServerForUri,
+  setTimeoutForUri,
 } from "../commands/workspaceCommand";
 import { DataSourceCommand, DataSourceMessage2 } from "../models/messages";
 import { MetaObjectPayload } from "../models/meta";
 import { UDA } from "../models/uda";
-import { getBasename, offerConnectAction } from "../utils/core";
+import {
+  calculateSeconds,
+  deconstructSeconds,
+  getBasename,
+  offerConnectAction,
+} from "../utils/core";
 import { getNonce } from "../utils/getNonce";
 import { MessageKind, Runner, notify } from "../utils/notifications";
 import { RunFlag, notifyExecution } from "../utils/queryUtils";
@@ -121,6 +128,8 @@ export class DataSourceEditorProvider implements CustomTextEditorProvider {
     const updateWebview = async () => {
       if (changing === 0) {
         const selectedServer = getServerForUri(document.uri) || "";
+        const timeout = getTimeoutForUri(document.uri);
+        const timeoutParts = deconstructSeconds(timeout.value);
         const selectedServerVersion =
           await connMngService.retrieveInsightsConnVersion(selectedServer);
         await getConnectionForServer(selectedServer);
@@ -129,6 +138,9 @@ export class DataSourceEditorProvider implements CustomTextEditorProvider {
         webview.postMessage(<DataSourceMessage2>{
           command: DataSourceCommand.Update,
           selectedServer,
+          timeoutUnit: timeoutParts.unit,
+          timeoutDefault: timeout.source === "workspace",
+          timeoutValue: timeoutParts.value,
           servers: getInsightsServers(),
           selectedServerVersion,
           dataSourceFile: this.getDocumentAsJson(document),
@@ -176,6 +188,19 @@ export class DataSourceEditorProvider implements CustomTextEditorProvider {
           updateWebview();
           break;
         }
+        case DataSourceCommand.Timeout: {
+          if (msg.timeoutDefault) {
+            await setTimeoutForUri(document.uri, undefined);
+          } else {
+            await setTimeoutForUri(
+              document.uri,
+              calculateSeconds(msg.timeoutValue, msg.timeoutUnit),
+            );
+          }
+
+          updateWebview();
+          break;
+        }
         case DataSourceCommand.Change: {
           const changed = msg.dataSourceFile;
           const current = this.getDocumentAsJson(document);
@@ -215,6 +240,7 @@ export class DataSourceEditorProvider implements CustomTextEditorProvider {
               msg.dataSourceFile,
               msg.selectedServer,
               this.filenname,
+              calculateSeconds(msg.timeoutValue, msg.timeoutUnit),
             ),
           );
           runner.location = ProgressLocation.Notification;

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -692,3 +692,45 @@ export function isQuick(server: string | undefined) {
 export function isQuickAlias(alias: string | undefined) {
   return alias?.startsWith("(");
 }
+
+export function calculateSeconds(value: number, unit: string): number {
+  switch (unit) {
+    case "Seconds":
+      return value;
+    case "Minutes":
+      return value * 60;
+    case "Hours":
+      return value * 60 * 60;
+    default:
+      return value;
+  }
+}
+
+export function deconstructSeconds(seconds: number): {
+  value: number;
+  unit: "Seconds" | "Minutes" | "Hours";
+} {
+  const minutes = seconds / 60;
+  const hours = minutes / 60;
+
+  if (hours > 0 && hours % 1 === 0) {
+    return { value: hours, unit: "Hours" };
+  } else if (minutes > 0 && minutes % 1 === 0) {
+    return { value: minutes, unit: "Minutes" };
+  } else {
+    return { value: seconds, unit: "Seconds" };
+  }
+}
+
+export function formatSeconds(seconds: number): string {
+  const minutes = seconds / 60;
+  const hours = minutes / 60;
+
+  if (hours >= 1 && hours % 1 === 0) {
+    return `${hours}h`;
+  } else if (minutes >= 1 && minutes % 1 === 0) {
+    return `${minutes}m`;
+  } else {
+    return `${seconds}s`;
+  }
+}

--- a/src/utils/queryUtils.ts
+++ b/src/utils/queryUtils.ts
@@ -279,6 +279,35 @@ export function normalizePyQuery(query: string): string {
   );
 }
 
+/**
+ * Generate request headers including timeout
+ * @param {Number} timeout - request timeout (ms)
+ * @param {('struct-text'|'json')} type - type of response to accept
+ */
+export function getHeaders(
+  timeout?: number,
+  type: "json" | "struct-text" = "json",
+) {
+  const headers: Record<string, boolean | string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (type === "struct-text") {
+    headers["Accept"] = "application/struct-text";
+  } else if (type === "json") {
+    headers["Accept"] = "application/json";
+    headers["json"] = true;
+  } else {
+    throw "Unsupported type";
+  }
+
+  if (timeout) {
+    headers["timeout"] = String(timeout);
+  }
+
+  return headers;
+}
+
 export function getPythonWrapper(
   query: string,
   returnFormat: "serialized" | "text" | "structuredText",

--- a/src/webview/components/kdbDataSourceView.ts
+++ b/src/webview/components/kdbDataSourceView.ts
@@ -157,6 +157,9 @@ export class KdbDataSourceView extends LitElement {
   running = false;
   servers: string[] = [];
   selectedServer = "";
+  timeoutDefault = true;
+  timeoutUnit = "Seconds";
+  timeoutValue = 0;
   updating = 0;
   view: {
     dap: (
@@ -199,6 +202,9 @@ export class KdbDataSourceView extends LitElement {
     if (msg.command === DataSourceCommand.Update) {
       this.servers = msg.servers;
       this.selectedServer = msg.selectedServer;
+      this.timeoutDefault = msg.timeoutDefault;
+      this.timeoutValue = msg.timeoutValue;
+      this.timeoutUnit = msg.timeoutUnit;
       this.selectedServerVersion = msg.selectedServerVersion
         ? msg.selectedServerVersion
         : 0;
@@ -360,6 +366,8 @@ export class KdbDataSourceView extends LitElement {
       command: DataSourceCommand.Run,
       selectedServer: this.selectedServer,
       dataSourceFile: this.data,
+      timeoutValue: this.timeoutValue,
+      timeoutUnit: this.timeoutUnit,
     });
   }
 
@@ -385,6 +393,39 @@ export class KdbDataSourceView extends LitElement {
     this.postMessage({
       command: DataSourceCommand.Server,
       selectedServer: this.selectedServer,
+    });
+  }
+
+  requestTimeoutDefaultChange(event: Event) {
+    this.timeoutDefault = (event.target as HTMLInputElement).checked;
+    this.requestUpdate();
+    this.postMessage({
+      command: DataSourceCommand.Timeout,
+      timeoutValue: this.timeoutValue,
+      timeoutUnit: this.timeoutUnit,
+      timeoutDefault: this.timeoutDefault,
+    });
+  }
+
+  requestTimeoutUnitChange(event: Event) {
+    this.timeoutUnit = (event.target as HTMLSelectElement).value;
+    this.requestUpdate();
+    this.postMessage({
+      command: DataSourceCommand.Timeout,
+      timeoutValue: this.timeoutValue,
+      timeoutUnit: this.timeoutUnit,
+      timeoutDefault: this.timeoutDefault,
+    });
+  }
+
+  requestTimeoutValueChange(event: Event) {
+    this.timeoutValue = Number((event.target as HTMLInputElement).value);
+    this.requestUpdate();
+    this.postMessage({
+      command: DataSourceCommand.Timeout,
+      timeoutValue: this.timeoutValue,
+      timeoutUnit: this.timeoutUnit,
+      timeoutDefault: this.timeoutDefault,
     });
   }
 
@@ -1791,15 +1832,17 @@ export class KdbDataSourceView extends LitElement {
         .value="${live(this.selectedServer)}"
         @sl-change="${this.requestServerChange}"
         ?disabled="${this.running}">
-        ${!selectedServerExists
-          ? html`<sl-option .value="${live("")}" .selected="${live(true)}"
-              >(none)</sl-option
-            >`
-          : html`<sl-option
-              .value="${live(this.selectedServer)}"
-              .selected="${live(true)}"
-              >${this.selectedServer}</sl-option
-            >`}
+        ${
+          !selectedServerExists
+            ? html`<sl-option .value="${live("")}" .selected="${live(true)}"
+                >(none)</sl-option
+              >`
+            : html`<sl-option
+                .value="${live(this.selectedServer)}"
+                .selected="${live(true)}"
+                >${this.selectedServer}</sl-option
+              >`
+        }
         <small>Connections</small>
         ${this.servers.map(
           (server) => html`
@@ -1807,29 +1850,52 @@ export class KdbDataSourceView extends LitElement {
           `,
         )}
       </sl-select>
-      <sl-button-group>
-        <sl-button variant="primary" class="grow" @click="${this.save}"
-          >Save</sl-button
+      <div class="timeout ${this.isInsights ? "" : "display-none"}"">
+        <div class="timeout-header">
+          Timeout
+          <sl-checkbox
+            .checked="${live(this.timeoutDefault)}"
+            @sl-change="${this.requestTimeoutDefaultChange}">
+              Default
+          </sl-checkbox>
+        </div>
+        <div class="timeout-input ${this.timeoutDefault ? "display-none" : ""}">
+          <sl-input type="number" min="1" placeholder="Number" .value="${live(this.timeoutValue)}"
+            @sl-change="${this.requestTimeoutValueChange}"></sl-input>
+          <sl-select
+            .value="${live(this.timeoutUnit)}"
+            @sl-change="${this.requestTimeoutUnitChange}">
+            <sl-option value="Seconds">Seconds</sl-option>
+            <sl-option value="Minutes">Minutes</sl-option>
+            <sl-option value="Hours">Hours</sl-option>
+          </sl-select>
+        </div>
+      </div>
+
+        <sl-button-group>
+          <sl-button variant="primary" class="grow" @click="${this.save}"
+            >Save</sl-button
+          >
+          <sl-button
+            variant="neutral"
+            @click="${this.refresh}"
+            ?disabled="${this.running}"
+            >Refresh</sl-button
+          >
+        </sl-button-group>
+        <sl-button
+          variant="neutral"
+          @click="${this.run}"
+          ?disabled="${this.running}"
+          >Run</sl-button
         >
         <sl-button
           variant="neutral"
-          @click="${this.refresh}"
+          @click="${this.populateScratchpad}"
           ?disabled="${this.running}"
-          >Refresh</sl-button
+          >Populate Scratchpad</sl-button
         >
-      </sl-button-group>
-      <sl-button
-        variant="neutral"
-        @click="${this.run}"
-        ?disabled="${this.running}"
-        >Run</sl-button
-      >
-      <sl-button
-        variant="neutral"
-        @click="${this.populateScratchpad}"
-        ?disabled="${this.running}"
-        >Populate Scratchpad</sl-button
-      >
+      </div>
     `;
   }
 

--- a/src/webview/components/styles.ts
+++ b/src/webview/components/styles.ts
@@ -123,6 +123,7 @@ export const dataSourceStyles = css`
     display: flex;
     flex-flow: column nowrap;
     flex-grow: 0;
+    width: 13rem;
     gap: var(--sl-spacing-x-small);
     margin-top: calc(
       1rem * var(--sl-line-height-dense) + 3 * var(--sl-spacing-medium)
@@ -198,6 +199,27 @@ export const dataSourceStyles = css`
   .reset-widths-limit {
     min-width: 0%;
     max-width: 100%;
+  }
+
+  .timeout-header {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .timeout-input {
+    display: flex;
+    gap: 5px;
+  }
+
+  .timeout-input sl-input {
+    width: 34%;
+    min-width: unset;
+  }
+
+  .timeout-input sl-select {
+    width: 66%;
+    min-width: unset;
   }
 `;
 

--- a/test/suite/commands/workspaceCommand.test.ts
+++ b/test/suite/commands/workspaceCommand.test.ts
@@ -30,8 +30,10 @@ import * as widgets from "../../../src/utils/widgets";
 
 describe("workspaceCommand", () => {
   const kdbUri = vscode.Uri.file("test-kdb.q");
-  const insightsUri = vscode.Uri.file("test-insights.q");
+  const insightsUri = vscode.Uri.file("tests.q");
   const pythonUri = vscode.Uri.file("test-python.q");
+
+  const updateConfStub = sinon.stub();
 
   beforeEach(() => {
     const insightNode = new InsightsNode(
@@ -63,7 +65,7 @@ describe("workspaceCommand", () => {
     ext.activeTextEditor = <any>{
       document: {
         uri: insightsUri,
-        fileName: "test-insights.q",
+        fileName: "tests.q",
         getText() {
           return "";
         },
@@ -77,6 +79,9 @@ describe("workspaceCommand", () => {
       .stub(ConnectionManagementService.prototype, "retrieveMetaContent")
       .returns(JSON.stringify([{ assembly: "assembly", target: "target" }]));
     sinon.stub(vscode.workspace, "getConfiguration").value(() => {
+      const relativePath = (uri: vscode.Uri) =>
+        vscode.workspace.asRelativePath(uri, false);
+
       return {
         get(key: string) {
           switch (key) {
@@ -86,24 +91,31 @@ describe("workspaceCommand", () => {
               return [{ alias: "connection1" }];
             case "connectionMap":
               return {
-                [kdbUri.path]: "connection2",
-                [pythonUri.path]: "connection1",
-                [insightsUri.path]: "connection1",
+                [relativePath(kdbUri)]: "connection2",
+                [relativePath(pythonUri)]: "connection1",
+                [relativePath(insightsUri)]: "connection1",
               };
             case "targetMap":
               return {
-                [insightsUri.path]: "assembly target",
+                [relativePath(insightsUri)]: "assembly target",
+              };
+            case "defaultTimeout":
+              return 30;
+            case "timeoutMap":
+              return {
+                [relativePath(insightsUri)]: 45,
               };
           }
           return {};
         },
-        update() {},
+        update: updateConfStub,
       };
     });
   });
 
   afterEach(() => {
     sinon.restore();
+    updateConfStub.reset();
     ext.serverProvider = <any>{};
     ext.connectionsList.length = 0;
     ext.activeTextEditor = undefined;
@@ -149,6 +161,85 @@ describe("workspaceCommand", () => {
           "connection1",
         ),
       );
+    });
+  });
+
+  describe("timeouts", () => {
+    let unitStub: sinon.SinonStub;
+    let valueStub: sinon.SinonStub;
+    let notifyStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      unitStub = sinon.stub(vscode.window, "showQuickPick");
+      valueStub = sinon.stub(vscode.window, "showInputBox");
+      notifyStub = sinon.stub(notifications, "notify");
+    });
+
+    it("should show timeout options for Insights connections", async () => {
+      const spy = sinon.spy(ext.pickTimeoutItem, "show");
+      await workspaceCommand.setTimeoutItem(insightsUri);
+      sinon.assert.called(spy);
+    });
+
+    it("should hide timeout options for q connections", async () => {
+      const spy = sinon.spy(ext.pickTimeoutItem, "hide");
+      await workspaceCommand.setTimeoutItem(kdbUri);
+      sinon.assert.called(spy);
+    });
+
+    it("should hide timeout options for other files", async () => {
+      const spy = sinon.spy(ext.pickTimeoutItem, "hide");
+      await workspaceCommand.setTimeoutItem(vscode.Uri.file("main.js"));
+      sinon.assert.called(spy);
+    });
+
+    it("should set a valid timeout", async () => {
+      unitStub.resolves({ label: "Seconds" });
+      valueStub.resolves("30");
+
+      await workspaceCommand.pickTimeout(insightsUri);
+
+      sinon.assert.calledOnceWithExactly(
+        updateConfStub,
+        "timeoutMap",
+        sinon.match({
+          [vscode.workspace.asRelativePath(insightsUri, false)]: 30,
+        }),
+      );
+    });
+
+    it("should set a long timeout if user accepts", async () => {
+      unitStub.resolves({ label: "Minutes" });
+      valueStub.resolves("30");
+      notifyStub.resolves("Keep Timeout");
+
+      await workspaceCommand.pickTimeout(insightsUri);
+
+      sinon.assert.calledOnceWithMatch(
+        notifyStub,
+        sinon.match("High timeout warning"),
+      );
+      sinon.assert.calledOnceWithExactly(
+        updateConfStub,
+        "timeoutMap",
+        sinon.match({
+          [vscode.workspace.asRelativePath(insightsUri, false)]: 1800,
+        }),
+      );
+    });
+
+    it("should not set a long timeout if user cancels", async () => {
+      unitStub.resolves({ label: "Minutes" });
+      valueStub.resolves("30");
+      notifyStub.resolves("Cancel");
+
+      await workspaceCommand.pickTimeout(insightsUri);
+
+      sinon.assert.calledOnceWithMatch(
+        notifyStub,
+        sinon.match("High timeout warning"),
+      );
+      sinon.assert.notCalled(updateConfStub);
     });
   });
 
@@ -210,12 +301,12 @@ describe("workspaceCommand", () => {
   });
 
   describe("importOldDSFiles", () => {
-    let windowErrorStub,
-      windowWithProgressStub,
-      windowShowInfo,
-      workspaceFolderStub,
-      tokenOnCancellationRequestedStub,
-      kdbOutputLogStub: sinon.SinonStub;
+    let windowErrorStub: sinon.SinonStub;
+    let windowWithProgressStub: sinon.SinonStub;
+    let windowShowInfo: sinon.SinonStub;
+    let workspaceFolderStub: sinon.SinonStub;
+    let tokenOnCancellationRequestedStub: sinon.SinonStub;
+    let kdbOutputLogStub: sinon.SinonStub;
 
     beforeEach(() => {
       windowErrorStub = sinon.stub(vscode.window, "showErrorMessage");

--- a/test/suite/utils/core.test.ts
+++ b/test/suite/utils/core.test.ts
@@ -943,4 +943,33 @@ describe("core", () => {
       assert.strictEqual(executeCommandStub.called, false);
     });
   });
+
+  describe("Seconds", () => {
+    it("should calculate seconds correctly", () => {
+      assert.strictEqual(coreUtils.calculateSeconds(30, "Seconds"), 30);
+      assert.strictEqual(coreUtils.calculateSeconds(30, "Minutes"), 1800);
+      assert.strictEqual(coreUtils.calculateSeconds(7, "Hours"), 25200);
+    });
+
+    it("should deconstruct seconds correctly", () => {
+      assert.deepStrictEqual(coreUtils.deconstructSeconds(30), {
+        value: 30,
+        unit: "Seconds",
+      });
+      assert.deepStrictEqual(coreUtils.deconstructSeconds(1800), {
+        value: 30,
+        unit: "Minutes",
+      });
+      assert.deepStrictEqual(coreUtils.deconstructSeconds(25200), {
+        value: 7,
+        unit: "Hours",
+      });
+    });
+
+    it("should format seconds correctly", () => {
+      assert.strictEqual(coreUtils.formatSeconds(30), "30s");
+      assert.strictEqual(coreUtils.formatSeconds(1800), "30m");
+      assert.strictEqual(coreUtils.formatSeconds(25200), "7h");
+    });
+  });
 });

--- a/test/suite/utils/queryUtils.test.ts
+++ b/test/suite/utils/queryUtils.test.ts
@@ -611,6 +611,34 @@ describe("queryUtils", () => {
     });
   });
 
+  describe("getHeaders", () => {
+    const jsonHeaders = {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      json: true,
+    };
+
+    const structTextHeaders = {
+      Accept: "application/struct-text",
+      "Content-Type": "application/json",
+    };
+
+    it("should return JSON headers by default", () => {
+      const res = queryUtils.getHeaders();
+      assert.deepStrictEqual(res, jsonHeaders);
+    });
+
+    it("should return JSON headers with timeout", () => {
+      const res = queryUtils.getHeaders(30, "json");
+      assert.deepStrictEqual(res, { ...jsonHeaders, timeout: "30" });
+    });
+
+    it("should return Structured Text headers with timeout", () => {
+      const res = queryUtils.getHeaders(30, "struct-text");
+      assert.deepStrictEqual(res, { ...structTextHeaders, timeout: "30" });
+    });
+  });
+
   describe("getQSQLWrapper", () => {
     let queryWrappeStub: sinon.SinonStub;
 

--- a/test/suite/webPanels/webViews/kdbDataSourceView.test.ts
+++ b/test/suite/webPanels/webViews/kdbDataSourceView.test.ts
@@ -46,79 +46,85 @@ describe("KdbDataSourceView", () => {
   }
 
   function createMessageEvent(isInsights: boolean) {
-    return <MessageEvent<DataSourceMessage2>>{
-      data: {
-        command: DataSourceCommand.Update,
-        servers: ["server"],
-        selectedServer: "server",
-        isInsights,
-        insightsMeta: <MetaObjectPayload>{
-          dap: [
-            {
-              assembly: "test-assembly",
-              instance: "instance1",
-              dap: "dap1",
+    const eventData: DataSourceMessage2 = {
+      command: DataSourceCommand.Update,
+      servers: ["server"],
+      selectedServer: "server",
+      selectedServerVersion: 0,
+      timeoutDefault: true,
+      timeoutValue: 0,
+      timeoutUnit: "Seconds",
+      isInsights,
+      insightsMeta: <MetaObjectPayload>{
+        dap: [
+          {
+            assembly: "test-assembly",
+            instance: "instance1",
+            dap: "dap1",
+          },
+        ],
+        api: [{ api: "getData" }],
+        assembly: [{ assembly: "test-assembly", tbls: ["table1"] }],
+        schema: [
+          {
+            table: "table1",
+            columns: [{ column: "column1" }],
+            assembly: "test-assembly",
+            type: "type",
+          },
+        ],
+      },
+      UDAs: [],
+      dataSourceFile: {
+        dataSource: {
+          selectedType: DataSourceTypes.API,
+          api: {
+            selectedApi: "getData",
+            table: "table1",
+            startTS: "",
+            endTS: "",
+            fill: "zero",
+            temporality: "snapshot",
+            filter: [],
+            groupBy: [],
+            agg: [],
+            sortCols: [],
+            slice: [],
+            labels: [],
+            optional: {
+              filled: false,
+              temporal: false,
+              rowLimit: false,
+              filters: [createFilter()],
+              labels: [createLabel()],
+              sorts: [createSort()],
+              aggs: [createAgg()],
+              groups: [createGroup()],
             },
-          ],
-          api: [{ api: "getData" }],
-          assembly: [{ assembly: "test-assembly", tbls: ["table1"] }],
-          schema: [
-            {
-              table: "table1",
-              columns: [{ column: "column1" }],
-              assembly: "test-assembly",
-              type: "type",
-            },
-          ],
-        },
-        UDAs: [],
-        dataSourceFile: {
-          dataSource: {
-            selectedType: DataSourceTypes.API,
-            api: {
-              selectedApi: "getData",
-              table: "table1",
-              startTS: "",
-              endTS: "",
-              fill: "zero",
-              temporality: "snapshot",
-              filter: [],
-              groupBy: [],
-              agg: [],
-              sortCols: [],
-              slice: [],
-              labels: [],
-              optional: {
-                filled: false,
-                temporal: false,
-                rowLimit: false,
-                filters: [createFilter()],
-                labels: [createLabel()],
-                sorts: [createSort()],
-                aggs: [createAgg()],
-                groups: [createGroup()],
-              },
-            },
-            qsql: {
-              query: "",
-              selectedTarget: "",
-            },
-            sql: {
-              query: "",
-            },
-            uda: {
-              name: "test",
-              description: "test description",
-              params: [],
-              return: {
-                type: ["99"],
-                description: "test return description",
-              },
+          },
+          qsql: {
+            query: "",
+            selectedTarget: "",
+          },
+          sql: {
+            query: "",
+          },
+          uda: {
+            name: "test",
+            description: "test description",
+            params: [],
+            return: {
+              type: ["99"],
+              description: "test return description",
             },
           },
         },
       },
     };
+
+    return new MessageEvent<DataSourceMessage2>("message", {
+      data: eventData,
+    });
   }
 
   function testEventHandlers(result: TemplateResult) {
@@ -993,6 +999,39 @@ describe("KdbDataSourceView", () => {
       sinon.stub(view, "postMessage").value(() => (result = true));
       view.requestServerChange(createValueEvent("server"));
       assert.ok(result);
+    });
+  });
+
+  describe("requestTimeoutChange", () => {
+    it("should send the correct message for default change", () => {
+      let timeoutDefault = false;
+      sinon
+        .stub(view, "postMessage")
+        .value((val: any) => (timeoutDefault = val.timeoutDefault));
+      view.requestTimeoutDefaultChange((<unknown>{
+        target: <HTMLInputElement>{
+          checked: true,
+        },
+      }) as Event);
+      assert.equal(timeoutDefault, true);
+    });
+
+    it("should send the correct message for unit change", () => {
+      let timeoutUnit = "Seconds";
+      sinon
+        .stub(view, "postMessage")
+        .value((val: any) => (timeoutUnit = val.timeoutUnit));
+      view.requestTimeoutUnitChange(createValueEvent("Minutes"));
+      assert.equal(timeoutUnit, "Minutes");
+    });
+
+    it("should send the correct message for value change", () => {
+      let timeoutValue = 123;
+      sinon
+        .stub(view, "postMessage")
+        .value((val: any) => (timeoutValue = val.timeoutValue));
+      view.requestTimeoutValueChange(createValueEvent("45"));
+      assert.equal(timeoutValue, 45);
     });
   });
 


### PR DESCRIPTION
### Changes introduced by this PR

- Timeout functionality for datasources and q/py queries when connected to Insights
- Cancellation functionality for Scratchpad queriesi
