### PR TITLE
Use token for cleaner cancellations

### DIFF
--- a/src/classes/insightsConnection.ts
+++ b/src/classes/insightsConnection.ts
@@ -14,6 +14,7 @@
 import axios, { AxiosRequestConfig } from "axios";
 import { jwtDecode } from "jwt-decode";
 import * as url from "url";
+import { CancellationToken } from "vscode-languageclient";
 
 import { ext } from "../extensionVariables";
 import {
@@ -514,6 +515,7 @@ export class InsightsConnection {
     variableName: string,
     params: DataSourceFiles,
     silent?: boolean,
+    token?: CancellationToken,
     timeout?: number,
   ): Promise<void> {
     if (this.connected && this.connEndpoints) {
@@ -592,24 +594,26 @@ export class InsightsConnection {
       });
 
       return await axios(options).then((response: any) => {
-        if (response.data.error) {
-          notify(
-            "Error occured while populating scratchpad.",
-            silent ? MessageKind.DEBUG : MessageKind.ERROR,
-            {
-              logger,
-              params: { status: response.status },
-            },
-          );
-        } else {
-          notify(
-            `Scratchpad variable (${variableName}) populated.`,
-            silent ? MessageKind.DEBUG : MessageKind.INFO,
-            {
-              logger,
-              params: { status: response.status },
-            },
-          );
+        if (!token?.isCancellationRequested) {
+          if (response.data.error) {
+            notify(
+              "Error occured while populating scratchpad.",
+              silent ? MessageKind.DEBUG : MessageKind.ERROR,
+              {
+                logger,
+                params: { status: response.status },
+              },
+            );
+          } else {
+            notify(
+              `Scratchpad variable (${variableName}) populated.`,
+              silent ? MessageKind.DEBUG : MessageKind.INFO,
+              {
+                logger,
+                params: { status: response.status },
+              },
+            );
+          }
         }
       });
     } else {
@@ -791,7 +795,9 @@ export class InsightsConnection {
     return undefined;
   }
 
-  public async cancelScratchpad(): Promise<boolean | undefined> {
+  public async cancelScratchpad(
+    isPython?: boolean,
+  ): Promise<boolean | undefined> {
     if (this.connected && this.connEndpoints) {
       const scratchpadURL = new url.URL(
         this.connEndpoints.scratchpad.cancel,
@@ -817,7 +823,7 @@ export class InsightsConnection {
       return await axios(options)
         .then((_response: any) => {
           notify(
-            `Scratchpad cancel request sent for ${this.connLabel}.`,
+            `Scratchpad cancel request sent for ${this.connLabel}${isPython ? ", however, Python queries may ignore this." : "."}`,
             MessageKind.INFO,
             { logger, telemetry: "Connection.Cancel.ie.sp" },
           );

--- a/src/commands/dataSourceCommand.ts
+++ b/src/commands/dataSourceCommand.ts
@@ -13,7 +13,7 @@
 
 import * as fs from "fs";
 import path from "path";
-import { InputBoxOptions, window } from "vscode";
+import { CancellationToken, InputBoxOptions, window } from "vscode";
 
 import { ext } from "../extensionVariables";
 import {
@@ -86,6 +86,7 @@ export async function populateScratchpad(
   connLabel: string,
   outputVariable?: string,
   silent?: boolean,
+  token?: CancellationToken,
   timeout?: number,
 ): Promise<void> {
   const connMngService = new ConnectionManagementService();
@@ -113,6 +114,7 @@ export async function populateScratchpad(
       outputVariable,
       dataSourceForm,
       silent,
+      token,
       timeout,
     );
   } else {
@@ -128,6 +130,7 @@ export async function runDataSource(
   dataSourceForm: DataSourceFiles,
   connLabel: string,
   executorName: string,
+  token?: CancellationToken,
   timeout?: number,
 ): Promise<any> {
   if (DataSourcesPanel.running) {
@@ -193,7 +196,7 @@ export async function runDataSource(
     }
 
     ext.isDatasourceExecution = false;
-    if (res) {
+    if (res && !token?.isCancellationRequested) {
       const success = !res.error;
       const query = getQuery(fileContent, selectedType);
 

--- a/src/commands/serverCommand.ts
+++ b/src/commands/serverCommand.ts
@@ -1144,12 +1144,14 @@ export async function runQuery(
             connLabel,
             variable,
             undefined,
+            token,
             timeout,
           )
         : runDataSource(
             getPartialDatasourceFile(query, target, isSql, isPython),
             connLabel,
             executorName,
+            token,
             timeout,
           )
       : executeQuery(

--- a/src/commands/workspaceCommand.ts
+++ b/src/commands/workspaceCommand.ts
@@ -811,8 +811,16 @@ export async function runActiveEditor(type?: ExecutionTypes) {
         isInsights,
         timeout,
         () => {
-          if (isInsights && !target) {
-            conn.cancelScratchpad();
+          if (isInsights) {
+            if (target) {
+              notify(
+                `Cancel request sent for ${conn.connLabel}, however, the query will continue running on the database until it finishes or times out`,
+                MessageKind.INFO,
+                { logger },
+              );
+            } else {
+              conn.cancelScratchpad(isPython(uri));
+            }
           }
         },
       );
@@ -827,6 +835,14 @@ export async function runActiveEditor(type?: ExecutionTypes) {
           (isQuke(uri) ? RunFlag.Quke : 0),
       );
     } catch (error) {
+      // don't show message if execution was cancelled
+      if (
+        error instanceof Error &&
+        error.message.substring(0, 8) === "Canceled"
+      ) {
+        return;
+      }
+
       notify(
         `Executing ${executorName} on ${conn.connLabel} failed.`,
         MessageKind.ERROR,

--- a/src/commands/workspaceCommand.ts
+++ b/src/commands/workspaceCommand.ts
@@ -416,6 +416,12 @@ export async function pickConnection(uri: Uri) {
   }
   await setServerForUri(uri, picked);
 
+  if (server) {
+    setTimeoutItem(uri);
+  } else {
+    ext.pickTimeoutItem.hide();
+  }
+
   return picked;
   /* c8 ignore stop */
 }

--- a/src/services/dataSourceEditorProvider.ts
+++ b/src/services/dataSourceEditorProvider.ts
@@ -235,14 +235,38 @@ export class DataSourceEditorProvider implements CustomTextEditorProvider {
           break;
         }
         case DataSourceCommand.Run: {
-          runner = Runner.create(() =>
-            runDataSource(
-              msg.dataSourceFile,
-              msg.selectedServer,
-              this.filenname,
-              calculateSeconds(msg.timeoutValue, msg.timeoutUnit),
-            ),
-          );
+          runner = Runner.create(async (_, token) => {
+            const cancellation = new Promise((_, reject) => {
+              token.onCancellationRequested(() =>
+                reject(new Error("Cancelled")),
+              );
+            });
+
+            try {
+              return await Promise.race([
+                runDataSource(
+                  msg.dataSourceFile,
+                  msg.selectedServer,
+                  this.filenname,
+                  token,
+                  calculateSeconds(msg.timeoutValue, msg.timeoutUnit),
+                ),
+                cancellation,
+              ]);
+            } catch (err) {
+              if (err instanceof Error && err.message === "Cancelled") {
+                // user cancelled
+                notify(
+                  `Cancel request sent for ${msg.selectedServer}, however, the query will continue running on the database until it finishes or times out`,
+                  MessageKind.INFO,
+                  { logger },
+                );
+                return;
+              }
+
+              throw err;
+            }
+          });
           runner.location = ProgressLocation.Notification;
           runner.title = `Running ${getBasename(document.uri)} on ${msg.selectedServer}.`;
           if (connected) await runner.execute();
@@ -255,9 +279,39 @@ export class DataSourceEditorProvider implements CustomTextEditorProvider {
           break;
         }
         case DataSourceCommand.Populate: {
-          runner = Runner.create(() =>
-            populateScratchpad(msg.dataSourceFile, msg.selectedServer),
-          );
+          runner = Runner.create(async (_, token) => {
+            const cancellation = new Promise((_, reject) => {
+              token.onCancellationRequested(() =>
+                reject(new Error("Cancelled")),
+              );
+            });
+
+            try {
+              return await Promise.race([
+                populateScratchpad(
+                  msg.dataSourceFile,
+                  msg.selectedServer,
+                  undefined,
+                  undefined,
+                  token,
+                  calculateSeconds(msg.timeoutValue, msg.timeoutUnit),
+                ),
+                cancellation,
+              ]);
+            } catch (err) {
+              if (err instanceof Error && err.message === "Cancelled") {
+                // user cancelled
+                notify(
+                  `Scratchpad cancel request sent for ${msg.selectedServer}`,
+                  MessageKind.INFO,
+                  { logger, telemetry: "Connection.Cancel.ie.sp" },
+                );
+                return;
+              }
+
+              throw err;
+            }
+          });
           runner.title = "Populating scratchpad.";
           if (connected) await runner.execute();
           else if (await offerConnectAction(selectedServer))


### PR DESCRIPTION
### Changes introduced by this PR

- Passes CancellationToken to async functions to stop work when cancelled
- Adds cancellation promise to resolve promise when user cancels
- Adds info messages for datasource and python cancellations
