### PR TITLE
Insights: fix version parsing collapsing two-digit minors

### DIFF
--- a/src/classes/insightsConnection.ts
+++ b/src/classes/insightsConnection.ts
@@ -56,7 +56,7 @@ export class InsightsConnection {
   public meta?: MetaObject;
   public config?: InsightsConfig;
   public apiConfig?: InsightsApiConfig;
-  public insightsVersion?: number;
+  public insightsVersion?: string;
   public connEndpoints?: InsightsEndpoints;
   private scratchpadLogger?: ScratchpadLogger;
 
@@ -87,7 +87,7 @@ export class InsightsConnection {
   public async setActive() {
     if (
       this.insightsVersion &&
-      isBaseVersionGreaterOrEqual(this.insightsVersion, 1.18)
+      isBaseVersionGreaterOrEqual(this.insightsVersion, "1.18")
     ) {
       if (!this.scratchpadLogger) {
         this.scratchpadLogger = new ScratchpadLogger(this.node.details);
@@ -233,7 +233,7 @@ export class InsightsConnection {
     if (
       this.connected &&
       this.insightsVersion &&
-      isBaseVersionGreaterOrEqual(this.insightsVersion, 1.13)
+      isBaseVersionGreaterOrEqual(this.insightsVersion, "1.13")
     ) {
       const configUrl = new url.URL(
         ext.insightsAuthUrls.apiConfigUrl,
@@ -296,7 +296,7 @@ export class InsightsConnection {
     const version = match ? match[0].replace(/-/g, "") : null;
     if (version) {
       const [major, minor, _path] = version.split(".");
-      this.insightsVersion = parseFloat(`${major}.${minor}`);
+      this.insightsVersion = `${major}.${minor}`;
     }
   }
 
@@ -315,11 +315,11 @@ export class InsightsConnection {
     const getVersionGroup = (): string => {
       if (
         !this.insightsVersion ||
-        !isBaseVersionGreaterOrEqual(this.insightsVersion, 1.11)
+        !isBaseVersionGreaterOrEqual(this.insightsVersion, "1.11")
       ) {
         return "pre-1.11";
       }
-      if (!isBaseVersionGreaterOrEqual(this.insightsVersion, 1.14)) {
+      if (!isBaseVersionGreaterOrEqual(this.insightsVersion, "1.14")) {
         return "v1.11-1.13";
       }
       return "v1.14+";
@@ -416,7 +416,7 @@ export class InsightsConnection {
   public generateQSqlBody(
     query: string,
     assemblyTarget: string,
-    version?: number,
+    version?: string,
   ) {
     const [plainAssembly, tier, plainDap] =
       normalizeAssemblyTarget(assemblyTarget).split(/\s+/);
@@ -424,7 +424,7 @@ export class InsightsConnection {
     const assembly = this.retrieveCorrectAssemblyName(plainAssembly);
     const dap = this.retrieveCorrectDAPName(plainDap, tier);
 
-    if (version && isBaseVersionGreaterOrEqual(version, 1.13)) {
+    if (version && isBaseVersionGreaterOrEqual(version, "1.13")) {
       return {
         query,
         scope: {
@@ -751,7 +751,7 @@ export class InsightsConnection {
       };
 
       if (this.insightsVersion) {
-        if (isBaseVersionGreaterOrEqual(this.insightsVersion, 1.12)) {
+        if (isBaseVersionGreaterOrEqual(this.insightsVersion, "1.12")) {
           body.returnFormat = isTableView ? "structuredText" : "text";
         } else {
           body.isTableView = isTableView;
@@ -792,7 +792,7 @@ export class InsightsConnection {
             if (isTableView) {
               if (
                 this.insightsVersion &&
-                isBaseVersionGreaterOrEqual(this.insightsVersion, 1.12)
+                isBaseVersionGreaterOrEqual(this.insightsVersion, "1.12")
               ) {
                 response.data = JSON.parse(
                   response.data.data,

--- a/src/commands/serverCommand.ts
+++ b/src/commands/serverCommand.ts
@@ -904,7 +904,7 @@ export async function executeQuery(
 
   const selectedConn = connMngService.retrieveConnectedConnection(connLabel);
   const isInsights = selectedConn instanceof InsightsConnection;
-  const connVersion = isInsights ? (selectedConn.insightsVersion ?? 0) : 0;
+  const connVersion = isInsights ? (selectedConn.insightsVersion ?? "0") : "0";
 
   if (query.length === 0) {
     notify("Empty query.", MessageKind.DEBUG, {
@@ -1345,7 +1345,7 @@ export async function writeQueryResultsToView(
   isPython?: boolean,
   duration?: string,
   isFromConnTree?: boolean,
-  connVersion?: number,
+  connVersion?: string,
 ): Promise<void> {
   await commands.executeCommand(
     "kdb.resultsPanel.update",
@@ -1387,7 +1387,7 @@ export async function writeScratchpadResult(
   isPython: boolean,
   isWorkbook: boolean,
   duration: string,
-  connVersion: number,
+  connVersion: string,
 ): Promise<any> {
   let errorMsg;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -441,7 +441,7 @@ function registerResultsPanelCommands(): CommandRegistration[] {
       callback: (
         results: any,
         isInsights: boolean,
-        connVersion?: number,
+        connVersion?: string,
         isPython?: boolean,
       ) => {
         ext.resultsViewProvider.updateResults(

--- a/src/models/messages.ts
+++ b/src/models/messages.ts
@@ -45,7 +45,7 @@ export interface DataSourceMessage2 {
   timeoutValue: number;
   servers: string[];
   selectedServer: string;
-  selectedServerVersion: number;
+  selectedServerVersion: string;
   isInsights: boolean;
   insightsMeta: MetaObjectPayload;
   dataSourceFile: DataSourceFiles;

--- a/src/services/connectionManagerService.ts
+++ b/src/services/connectionManagerService.ts
@@ -393,7 +393,7 @@ export class ConnectionManagementService {
 
     if (
       conn.insightsVersion &&
-      isBaseVersionGreaterOrEqual(conn.insightsVersion, 1.13)
+      isBaseVersionGreaterOrEqual(conn.insightsVersion, "1.13")
     ) {
       const confirmationPrompt = `Reset Scratchpad? All data in the ${conn.connLabel} Scratchpad will be lost, and variables will be reset.`;
       const selection = await notify(
@@ -498,12 +498,12 @@ export class ConnectionManagementService {
     }
   }
 
-  public async retrieveInsightsConnVersion(connLabel: string): Promise<number> {
+  public async retrieveInsightsConnVersion(connLabel: string): Promise<string> {
     const connection = this.retrieveConnectedConnection(connLabel);
     if (!connection || !(connection instanceof InsightsConnection)) {
-      return 0;
+      return "0";
     }
-    return connection.insightsVersion ? connection.insightsVersion : 0;
+    return connection.insightsVersion ? connection.insightsVersion : "0";
   }
 
   public async retrieveInsightsConnQEEnabled(

--- a/src/services/kdbTreeProvider.ts
+++ b/src/services/kdbTreeProvider.ts
@@ -683,7 +683,7 @@ export class InsightsNode extends vscode.TreeItem {
     const qeEnabled = await connService.retrieveInsightsConnQEEnabled(
       this.label,
     );
-    if (version !== 0) {
+    if (version !== "0") {
       tooltipMd.appendMarkdown(`\nVersion: ${version}\n`);
     }
     if (qeEnabled !== undefined) {

--- a/src/services/notebookController.ts
+++ b/src/services/notebookController.ts
@@ -218,11 +218,11 @@ export class KxNotebookController {
 
   getInsightProps(conn: LocalConnection | InsightsConnection) {
     let isInsights = false;
-    let connVersion = 0;
+    let connVersion = "0";
 
     if (conn instanceof InsightsConnection) {
       isInsights = true;
-      connVersion = conn.insightsVersion ?? 0;
+      connVersion = conn.insightsVersion ?? "0";
     }
 
     return { isInsights, connVersion };
@@ -334,7 +334,7 @@ function render(
   results: any,
   isPython: boolean,
   isInsights: boolean,
-  connVersion?: number,
+  connVersion?: string,
 ): Rendered {
   let text = "No results.";
   let mime = "text/plain";

--- a/src/services/resultsPanelProvider.ts
+++ b/src/services/resultsPanelProvider.ts
@@ -83,7 +83,7 @@ export class KdbResultsViewProvider implements WebviewViewProvider {
   public updateResults(
     queryResults: any,
     isInsights?: boolean,
-    connVersion?: number,
+    connVersion?: string,
     isPython?: boolean,
   ) {
     this.savedParamStates = { queryResults, isInsights, connVersion, isPython };
@@ -141,7 +141,7 @@ export class KdbResultsViewProvider implements WebviewViewProvider {
       : "";
   }
 
-  public updateWebView(queryResult: any, connVersion?: number) {
+  public updateWebView(queryResult: any, connVersion?: string) {
     ext.resultPanelCSV = "";
     this._results = queryResult;
     let result = "";

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -683,8 +683,8 @@ function map(xs: any, f: any) {
 }
 
 export function isBaseVersionGreaterOrEqual(
-  baseVersion: number,
-  targetVersion: number,
+  baseVersion: string,
+  targetVersion: string,
 ): boolean {
   return semver.gte(`${baseVersion}.0`, `${targetVersion}.0`);
 }

--- a/src/utils/resultsRenderer.ts
+++ b/src/utils/resultsRenderer.ts
@@ -19,7 +19,7 @@ import { StructuredTextResults } from "../models/queryResult";
 export function convertToGrid(
   results: any,
   isInsights: boolean,
-  connVersion?: number,
+  connVersion?: string,
   isPython?: boolean,
 ): any {
   let rowData = [];
@@ -30,7 +30,7 @@ export function convertToGrid(
     /* TODO: Workaround for Python structuredText bug */
     (!isPython &&
       connVersion &&
-      isBaseVersionGreaterOrEqual(connVersion, 1.12)) ||
+      isBaseVersionGreaterOrEqual(connVersion, "1.12")) ||
     results.columns
   ) {
     rowData = updatedExtractRowData(results);

--- a/src/webview/components/kdbDataSourceView.ts
+++ b/src/webview/components/kdbDataSourceView.ts
@@ -137,7 +137,7 @@ export class KdbDataSourceView extends LitElement {
   rowLimitCount = "100000";
   isRowLimitLast = true;
   rowLimit = false;
-  selectedServerVersion = 0;
+  selectedServerVersion = "";
   endTS = "";
   fill = "";
   filled = false;
@@ -207,7 +207,7 @@ export class KdbDataSourceView extends LitElement {
       this.timeoutUnit = msg.timeoutUnit;
       this.selectedServerVersion = msg.selectedServerVersion
         ? msg.selectedServerVersion
-        : 0;
+        : "";
       this.isInsights = msg.isInsights;
       this.isMetaLoaded = !!msg.insightsMeta.dap;
       this.insightsMeta = msg.insightsMeta;

--- a/test/suite/commands/serverCommand.test.ts
+++ b/test/suite/commands/serverCommand.test.ts
@@ -709,7 +709,7 @@ describe("serverCommand", () => {
         false,
         true,
         "2",
-        0,
+        "0",
       );
       sinon.assert.notCalled(writeQueryResultsToViewStub);
       sinon.assert.notCalled(writeQueryResultsToConsoleStub);
@@ -726,7 +726,7 @@ describe("serverCommand", () => {
         true,
         true,
         "2",
-        0,
+        "0",
       );
       sinon.assert.notCalled(writeQueryResultsToConsoleStub);
       sinon.assert.notCalled(queryConsoleErrorStub);
@@ -743,7 +743,7 @@ describe("serverCommand", () => {
         true,
         true,
         "2",
-        0,
+        "0",
       );
       sinon.assert.notCalled(writeQueryResultsToViewStub);
     });

--- a/test/suite/services/connectionManagementService.test.ts
+++ b/test/suite/services/connectionManagementService.test.ts
@@ -447,14 +447,14 @@ describe("ConnectionManagementService", () => {
 
     it("should reset the scratchpad if the active connection is an InsightsConnection", async () => {
       ext.activeConnection = insightsConn;
-      ext.activeConnection.insightsVersion = 1.13;
+      ext.activeConnection.insightsVersion = "1.13";
       showInformationMessageStub.resolves("Yes");
       await connMngService.resetScratchpad();
       sinon.assert.calledOnce(resetScratchpadStub);
     });
 
     it("should retrieve insights connection and procced with resetScratchpad", async () => {
-      insightsConn.insightsVersion = 1.13;
+      insightsConn.insightsVersion = "1.13";
       retrieveConnectedConnectionStub.returns(insightsConn);
       showInformationMessageStub.resolves("Yes");
       await connMngService.resetScratchpad("test");
@@ -462,7 +462,7 @@ describe("ConnectionManagementService", () => {
     });
 
     it("should retrieve insights connection and procced with resetScratchpad", async () => {
-      insightsConn.insightsVersion = 1.13;
+      insightsConn.insightsVersion = "1.13";
       retrieveConnectedConnectionStub.returns(insightsConn);
       showInformationMessageStub.resolves("No");
       await connMngService.resetScratchpad("test");
@@ -485,7 +485,7 @@ describe("ConnectionManagementService", () => {
 
     it("should log an error if insightsVersion is less than or equal to 1.11", async () => {
       ext.activeConnection = insightsConn;
-      ext.activeConnection.insightsVersion = 1.11;
+      ext.activeConnection.insightsVersion = "1.11";
       await connMngService.resetScratchpad();
       sinon.assert.calledOnce(kdbOutputLogStub);
     });
@@ -706,7 +706,7 @@ describe("ConnectionManagementService", () => {
           "nonInsightsLabel",
         );
 
-      assert.strictEqual(result, 0);
+      assert.strictEqual(result, "0");
     });
 
     it("should return 1.11 in case of Insights connection with  version", async () => {
@@ -716,7 +716,7 @@ describe("ConnectionManagementService", () => {
           "insightsLabel",
         );
 
-      assert.strictEqual(result, 1.11);
+      assert.strictEqual(result, "1.11");
     });
 
     it("should not return the version of undefined connection", async () => {
@@ -726,7 +726,7 @@ describe("ConnectionManagementService", () => {
           "nonInsightsLabel",
         );
 
-      assert.strictEqual(result, 0);
+      assert.strictEqual(result, "0");
     });
 
     it("should return  0 in case of Insights with no connection version", async () => {
@@ -742,7 +742,7 @@ describe("ConnectionManagementService", () => {
           "insightsLabel",
         );
 
-      assert.strictEqual(result, 0);
+      assert.strictEqual(result, "0");
     });
   });
 

--- a/test/suite/utils/core.test.ts
+++ b/test/suite/utils/core.test.ts
@@ -972,4 +972,28 @@ describe("core", () => {
       assert.strictEqual(coreUtils.formatSeconds(25200), "7h");
     });
   });
+
+  describe("isBaseVersionGreaterOrEqual", () => {
+    it("should treat two-digit minor versions correctly, not as a collapsed float", () => {
+      assert.strictEqual(
+        coreUtils.isBaseVersionGreaterOrEqual("1.20", "1.18"),
+        true,
+      );
+      assert.strictEqual(
+        coreUtils.isBaseVersionGreaterOrEqual("1.2", "1.18"),
+        false,
+      );
+    });
+
+    it("should compare single-digit minor versions correctly", () => {
+      assert.strictEqual(
+        coreUtils.isBaseVersionGreaterOrEqual("1.13", "1.13"),
+        true,
+      );
+      assert.strictEqual(
+        coreUtils.isBaseVersionGreaterOrEqual("1.11", "1.13"),
+        false,
+      );
+    });
+  });
 });

--- a/test/suite/utils/core.test.ts
+++ b/test/suite/utils/core.test.ts
@@ -987,11 +987,11 @@ describe("core", () => {
 
     it("should compare single-digit minor versions correctly", () => {
       assert.strictEqual(
-        coreUtils.isBaseVersionGreaterOrEqual("1.13", "1.13"),
+        coreUtils.isBaseVersionGreaterOrEqual("1.3", "1.3"),
         true,
       );
       assert.strictEqual(
-        coreUtils.isBaseVersionGreaterOrEqual("1.11", "1.13"),
+        coreUtils.isBaseVersionGreaterOrEqual("1.1", "1.3"),
         false,
       );
     });

--- a/test/suite/webPanels/resultsPanelProvider.test.ts
+++ b/test/suite/webPanels/resultsPanelProvider.test.ts
@@ -231,7 +231,7 @@ describe("ResultsPanelProvider", () => {
         ],
       });
 
-      const output = renderer.convertToGrid(results, true, 1.12);
+      const output = renderer.convertToGrid(results, true, "1.12");
       assert.equal(JSON.stringify(output), expectedOutput);
     });
 
@@ -537,7 +537,7 @@ describe("ResultsPanelProvider", () => {
     it("should show the view and update the web view with insights", () => {
       const queryResults = { data: "test" };
       const isInsights = true;
-      const connVersion = 1.11;
+      const connVersion = "1.11";
 
       const updateWebViewStub = sinon.stub(resultsPanel, "updateWebView");
 
@@ -554,7 +554,7 @@ describe("ResultsPanelProvider", () => {
     it("should show the view and update the web view without insights", () => {
       const queryResults = { data: "test" };
       const isInsights = false;
-      const connVersion = 1.11;
+      const connVersion = "1.11";
 
       const updateWebViewStub = sinon.stub(resultsPanel, "updateWebView");
 
@@ -572,7 +572,7 @@ describe("ResultsPanelProvider", () => {
       resultsPanel["_view"] = undefined;
       const queryResults = { data: "test" };
       const isInsights = true;
-      const connVersion = 1.11;
+      const connVersion = "1.11";
 
       const updateWebViewStub = sinon.stub(resultsPanel, "updateWebView");
 

--- a/test/suite/webPanels/webViews/kdbDataSourceView.test.ts
+++ b/test/suite/webPanels/webViews/kdbDataSourceView.test.ts
@@ -50,7 +50,7 @@ describe("KdbDataSourceView", () => {
       command: DataSourceCommand.Update,
       servers: ["server"],
       selectedServer: "server",
-      selectedServerVersion: 0,
+      selectedServerVersion: "0",
       timeoutDefault: true,
       timeoutValue: 0,
       timeoutUnit: "Seconds",
@@ -1037,13 +1037,13 @@ describe("KdbDataSourceView", () => {
 
   describe("renderRowCountOptions", () => {
     it("should render row count options", () => {
-      view.selectedServerVersion = 1.11;
+      view.selectedServerVersion = "1.11";
       const result = view.renderRowCountOptions();
       assert.ok(result);
     });
 
     it("should not render row count options for older server version", () => {
-      view.selectedServerVersion = 1.1;
+      view.selectedServerVersion = "1.1";
       const result = view.renderRowCountOptions();
       assert.ok(!result);
     });


### PR DESCRIPTION
### Changes introduced by this PR

- Fixes a version-detection bug where two-digit minor server versions (e.g. Insights Enterprise 1.20) were misparsed via `parseFloat`, collapsing `1.20` to `1.2` and causing it to be misdetected as older than 1.11 — silently disabling every version-gated feature.
- Changes `insightsVersion`/`connVersion` from `number` to `string` throughout, and switches `isBaseVersionGreaterOrEqual` to compare version strings directly instead of round-tripping through a float.
- Updates affected tests and adds a regression test for two-digit minor versions.
