### PR TITLE
q-test: run in qpbuild docker image locally

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,16 +47,16 @@ npm run q-test                    # q-language unit tests — runs in the qpbuil
 
 `q-test` wraps [qcumber.sh](qcumber.sh), which runs the tests inside the
 `qpbuild` image and sets up pykx via `test/q/preTest.sh`. The image lives in a
-private GitLab registry — if it isn't already local, the script pulls it. It
-logs in first when it can: from `GITLAB_TOKEN` (a GitLab PAT with the
-`read_registry` scope), or by prompting interactively; otherwise it relies on an
-existing `docker login` (this is how CI authenticates — a `docker/login-action`
-step runs before `qcumber.sh`). It also needs a kdb+ license
-passed to the container as `KDB_K4LICENSE_B64` (this is how CI passes it, from a
-secret). If that env var is unset, `qcumber.sh` base64-encodes a `k4.lic` file,
-looked up as `$QLIC/k4.lic`, `$QHOME/k4.lic`, then `~/.kx/k4.lic` — so if you
-already have `$QLIC`/`$QHOME` set there's nothing to configure. (A `kc.lic` will
-not work; the tests need a `k4.lic`.)
+private GitLab registry — if it isn't already local, the script pulls it,
+relying on whatever credentials docker already has (this is how CI authenticates
+— a `docker/login-action` step runs before `qcumber.sh`). Only if that pull
+fails does it authenticate itself — from `GITLAB_TOKEN` (a GitLab PAT with the
+`read_registry` scope) or an interactive prompt — and retry once. It also needs
+a kdb+ license passed to the container as `KDB_K4LICENSE_B64` (this is how CI
+passes it, from a secret). If that env var is unset, `qcumber.sh` base64-encodes
+a `k4.lic` file, looked up as `$QLIC/k4.lic`, `$QHOME/k4.lic`, then
+`~/.kx/k4.lic` — so if you already have `$QLIC`/`$QHOME` set there's nothing to
+configure. (A `kc.lic` will not work; the tests need a `k4.lic`.)
 
 Test framework is **Mocha** with **Sinon** for stubs and
 **proxyquire**/**mock-fs** for module and filesystem mocking. Tests mirror the
@@ -137,8 +137,9 @@ execution target via the `kdb.connectionMap`/`kdb.targetMap` workspace settings.
 - **Dependencies**: pin every package to an absolute version (no `^`/`~` ranges)
   and commit the updated `package-lock.json`.
 - **Branching**: PRs target `dev` (the default branch), not `main`.
-- **Commit messages**: a single line, no body/newlines. Lead with the affected
-  area, then a comma-separated summary of what changed, e.g.
+- **Commit messages**: a single line, no body/newlines and no `Co-Authored-By`
+  trailer. Lead with the affected area, then a comma-separated summary of what
+  changed, e.g.
   `REPL: add word nav/delete keys, route orphan files to active REPL, dedupe query normalization`.
 - **Squashing**: interactive rebase isn't available here — squash with a soft
   reset instead, then re-commit in the style above, e.g.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,21 @@ npm run test:file <path>          # Single test file (TEST_FILE env)
 npm run test:folder <path>        # A folder of tests (TEST_FOLDER env)
 npm run coverage                  # Same suite under c8 coverage
 npm run ui-test                   # End-to-end UI tests via vscode-extension-tester (test/ui/**)
-npm run q-test                    # q-language unit tests (requires a q runtime on PATH; uses qcumber.q)
+npm run q-test                    # q-language unit tests — runs in the qpbuild docker image (no local q needed)
 ```
+
+`q-test` wraps [qcumber.sh](qcumber.sh), which runs the tests inside the
+`qpbuild` image and sets up pykx via `test/q/preTest.sh`. The image lives in a
+private GitLab registry — if it isn't already local, the script pulls it. It
+logs in first when it can: from `GITLAB_TOKEN` (a GitLab PAT with the
+`read_registry` scope), or by prompting interactively; otherwise it relies on an
+existing `docker login` (this is how CI authenticates — a `docker/login-action`
+step runs before `qcumber.sh`). It also needs a kdb+ license
+passed to the container as `KDB_K4LICENSE_B64` (this is how CI passes it, from a
+secret). If that env var is unset, `qcumber.sh` base64-encodes a `k4.lic` file,
+looked up as `$QLIC/k4.lic`, `$QHOME/k4.lic`, then `~/.kx/k4.lic` — so if you
+already have `$QLIC`/`$QHOME` set there's nothing to configure. (A `kc.lic` will
+not work; the tests need a `k4.lic`.)
 
 Test framework is **Mocha** with **Sinon** for stubs and
 **proxyquire**/**mock-fs** for module and filesystem mocking. Tests mirror the

--- a/package.json
+++ b/package.json
@@ -1242,7 +1242,7 @@
     "ui-test-cmd": "extest setup-and-run --code_version 1.103.0 --code_settings ./test/ui/fixtures/settings.json --extensions_dir ./.test-extensions --storage ./.test-folder -m ./test/ui/fixtures/mocha.json",
     "preui-test": "rimraf out-test .test-extensions",
     "ui-test": "npm run ui-test-cmd -- ./out-test/test/ui/**/*.test.js",
-    "q-test": "q qcumber.q -color -src ./test/q/main.q -test ./test/q/tests",
+    "q-test": "bash qcumber.sh -src test/q/main.q -test test/q/tests",
     "mock-insights-server": "node --experimental-strip-types scripts/mock-insights-server/server.ts"
   },
   "devDependencies": {

--- a/qcumber.sh
+++ b/qcumber.sh
@@ -19,6 +19,13 @@ fi
 
 if [ -z "$KDB_K4LICENSE_B64" ]; then
     echo "error: no kdb+ license found. Set KDB_K4LICENSE_B64, or place k4.lic in \$QLIC, \$QHOME, or ~/.kx/." >&2
+    # This caveat is because neither shell-specific dot files nor /etc/environment are read
+    # when starting non-interactive non-login shells in Windows.
+    # WSLENV lives in the Windows registry, and stores what windows env vars get forwarded to WSL
+    # > notepad $PROFILE
+    # Add the line$env:QLIC="/home/username/q"
+    # > setx WSLENV "$($env:WSLENV):QLIC"
+    echo "On Windows, at least one of these must be passed in via WSLENV." >&2
     exit 1
 fi
 

--- a/qcumber.sh
+++ b/qcumber.sh
@@ -26,24 +26,30 @@ QBUILD_IMAGE="registry.gitlab.com/kxdev/cloud/packaging/qpacker/qpbuild:2.1.41"
 QBUILD_REGISTRY="registry.gitlab.com"
 
 # The image lives in a private GitLab registry. If it isn't already local, pull
-# it. We log in first only when we have a way to: GITLAB_TOKEN (a GitLab PAT with
-# read_registry scope), or an interactive prompt. Otherwise we assume docker is
-# already authenticated (e.g. CI logs in via docker/login-action beforehand).
+# it, relying on whatever credentials docker already has (this is how CI works:
+# a docker/login-action step logs in beforehand). Only if that pull fails do we
+# authenticate ourselves — from GITLAB_TOKEN (a GitLab PAT with read_registry
+# scope) or an interactive prompt — and try once more.
 if ! docker image inspect "$QBUILD_IMAGE" >/dev/null 2>&1; then
     echo "image $QBUILD_IMAGE not found locally; pulling from $QBUILD_REGISTRY (private)."
-    if [ -z "$GITLAB_TOKEN" ] && [ -t 0 ]; then
-        read -rsp "GitLab token (read_registry scope, blank if already logged in): " GITLAB_TOKEN
-        echo
-    fi
-    if [ -n "$GITLAB_TOKEN" ]; then
+    if ! docker pull "$QBUILD_IMAGE"; then
+        echo "pull failed; authenticating to $QBUILD_REGISTRY and retrying." >&2
+        if [ -z "$GITLAB_TOKEN" ] && [ -t 0 ]; then
+            read -rsp "GitLab token (read_registry scope): " GITLAB_TOKEN
+            echo
+        fi
+        if [ -z "$GITLAB_TOKEN" ]; then
+            echo "error: failed to pull $QBUILD_IMAGE. Log in to $QBUILD_REGISTRY (docker login) or set GITLAB_TOKEN." >&2
+            exit 1
+        fi
         if ! echo "$GITLAB_TOKEN" | docker login "$QBUILD_REGISTRY" -u oauth2 --password-stdin; then
             echo "error: docker login to $QBUILD_REGISTRY failed." >&2
             exit 1
         fi
-    fi
-    if ! docker pull "$QBUILD_IMAGE"; then
-        echo "error: failed to pull $QBUILD_IMAGE. Log in to $QBUILD_REGISTRY (docker login) or set GITLAB_TOKEN." >&2
-        exit 1
+        if ! docker pull "$QBUILD_IMAGE"; then
+            echo "error: failed to pull $QBUILD_IMAGE after login." >&2
+            exit 1
+        fi
     fi
 fi
 

--- a/qcumber.sh
+++ b/qcumber.sh
@@ -3,8 +3,50 @@
 # Runs qcumber in a docker image
 # usage:
 # qcumber.sh -src test/main.q -test test
+#
+# License: the container needs a kdb+ license as the KDB_K4LICENSE_B64 env var
+# (this is how CI passes it, from a secret). If unset, this script base64-encodes
+# a k4.lic file, looked up in order: $QLIC/k4.lic, $QHOME/k4.lic, ~/.kx/k4.lic
+
+if [ -z "$KDB_K4LICENSE_B64" ]; then
+    for lic in "$QLIC/k4.lic" "$QHOME/k4.lic" "$HOME/.kx/k4.lic"; do
+        if [ -n "$lic" ] && [ -f "$lic" ]; then
+            export KDB_K4LICENSE_B64=$(base64 -i "$lic")
+            break
+        fi
+    done
+fi
+
+if [ -z "$KDB_K4LICENSE_B64" ]; then
+    echo "error: no kdb+ license found. Set KDB_K4LICENSE_B64, or place k4.lic in \$QLIC, \$QHOME, or ~/.kx/." >&2
+    exit 1
+fi
 
 QBUILD_IMAGE="registry.gitlab.com/kxdev/cloud/packaging/qpacker/qpbuild:2.1.41"
+QBUILD_REGISTRY="registry.gitlab.com"
+
+# The image lives in a private GitLab registry. If it isn't already local, pull
+# it. We log in first only when we have a way to: GITLAB_TOKEN (a GitLab PAT with
+# read_registry scope), or an interactive prompt. Otherwise we assume docker is
+# already authenticated (e.g. CI logs in via docker/login-action beforehand).
+if ! docker image inspect "$QBUILD_IMAGE" >/dev/null 2>&1; then
+    echo "image $QBUILD_IMAGE not found locally; pulling from $QBUILD_REGISTRY (private)."
+    if [ -z "$GITLAB_TOKEN" ] && [ -t 0 ]; then
+        read -rsp "GitLab token (read_registry scope, blank if already logged in): " GITLAB_TOKEN
+        echo
+    fi
+    if [ -n "$GITLAB_TOKEN" ]; then
+        if ! echo "$GITLAB_TOKEN" | docker login "$QBUILD_REGISTRY" -u oauth2 --password-stdin; then
+            echo "error: docker login to $QBUILD_REGISTRY failed." >&2
+            exit 1
+        fi
+    fi
+    if ! docker pull "$QBUILD_IMAGE"; then
+        echo "error: failed to pull $QBUILD_IMAGE. Log in to $QBUILD_REGISTRY (docker login) or set GITLAB_TOKEN." >&2
+        exit 1
+    fi
+fi
+
 CMD="/app/qbuild/scripts/qcumber -color -q $*"
 SETUP="if [ -f /app/project/test/q/preTest.sh ]; then source /app/project/test/q/preTest.sh; fi"
 


### PR DESCRIPTION
### Changes introduced by this PR

- **`npm run q-test` now runs in Docker** — switched the script from invoking a local `q qcumber.q` (which required q on PATH) to running the test suite inside the private `qpbuild` image via `qcumber.sh`. No local q install needed.
- **Automatic license resolution** — `qcumber.sh` passes the kdb+ license to the container as `KDB_K4LICENSE_B64` (how CI supplies it, from a secret). If that env var is unset, it base64-encodes a `k4.lic` found in `$QLIC`, `$QHOME`, or `~/.kx` — so no manual setup when those are already configured.
- **Private-registry pull** — the `qpbuild` image lives in a private GitLab registry. If it isn't already local, the script pulls it. It logs in first when it can — from `GITLAB_TOKEN` (a GitLab PAT with `read_registry` scope) or an interactive prompt — otherwise it relies on an existing `docker login`.
- **Works in CI** — GitHub Actions authenticates with a `docker/login-action` step before running `qcumber.sh`, so no `GITLAB_TOKEN` is needed there; the license is supplied as the `KDB_K4LICENSE_B64` secret. If a pull fails with no credentials, the script errors with a clear message.

