### PR TITLE
KXI-72215 Set all .sh files to be checked out with LF line endings, so they run under bash on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# When the repo is cloned into windows, the scripts still need LF line endings to run in bash
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-# When the repo is cloned into windows, the scripts still need LF line endings to run in bash
+# When the repo is cloned into windows, the scripts need LF line endings to run in bash
 *.sh text eol=lf


### PR DESCRIPTION
### Changes introduced by this PR

- `npm run q-test` runs multiple bash scripts, but if these were checked out with windows line endings, they can't be parsed. With this change, they'll be checked out with \n line endings so the q tests can be run under windows