### PR TITLE
Run app-sec (SonarQube + Snyk) on fork PRs via workflow_run

### DIFF
--- a/.github/workflows/app-sec-forks.yml
+++ b/.github/workflows/app-sec-forks.yml
@@ -1,0 +1,94 @@
+# Application Security for fork PRs.
+#
+# Fork PRs receive no secrets from the `pull_request` event (GitHub's anti-
+# exfiltration protection), so the inline `app-sec` job in dev.yml / main.yml is
+# skipped for them. This workflow re-runs the full app-sec suite (SonarQube +
+# Snyk) for fork PRs using the `workflow_run` trigger, which executes in the
+# base-repo context on the default branch and therefore *does* have secrets.
+#
+# SECURITY: this workflow runs with secrets in scope while analysing untrusted
+# fork code. It only READS fork source (the SonarQube scanner does not execute
+# it) and installs dependencies with lifecycle scripts disabled
+# (ignore_scripts: true). Do NOT add steps here that execute fork-authored code.
+#
+# Note: fork CI cannot run the `test-q` job (needs GitLab registry / KDB license
+# secrets), so the triggering run rarely concludes 'success'. We therefore do
+# not gate on conclusion; instead the run self-gates on the presence of the
+# `lcov` artifact, which only exists if the Linux unit-test job got that far.
+
+name: Application Security (fork PRs)
+
+on:
+  workflow_run:
+    workflows:
+      - "KX VScode CI Dev Testing"
+      - "KX VScode CI Main Testing"
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  statuses: write
+
+jobs:
+  meta:
+    runs-on: ubuntu-latest
+    # Only handle fork PRs — same-repo PRs are covered by the inline app-sec job.
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name != github.event.workflow_run.repository.full_name
+    outputs:
+      pr_number: ${{ steps.meta.outputs.PR_NUMBER }}
+      head_repo: ${{ steps.meta.outputs.PR_HEAD_REPO }}
+      head_sha: ${{ steps.meta.outputs.PR_HEAD_SHA }}
+      head_ref: ${{ steps.meta.outputs.PR_HEAD_REF }}
+      base_ref: ${{ steps.meta.outputs.PR_BASE_REF }}
+    steps:
+      - name: Download PR metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-meta
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Parse PR metadata
+        id: meta
+        # pr.env is produced from GitHub context values in the CI workflow (not
+        # from fork file contents); git ref/name charset rules keep these safe
+        # to append as step outputs.
+        run: cat pr.env >> "$GITHUB_OUTPUT"
+
+  app-sec:
+    needs: meta
+    uses: ./.github/workflows/app-sec-template.yml
+    with:
+      # Not 'dev'/'main', so Snyk Monitor is skipped for PR analysis.
+      github_ref: pr/${{ needs.meta.outputs.pr_number }}
+      checkout_repository: ${{ needs.meta.outputs.head_repo }}
+      checkout_ref: ${{ needs.meta.outputs.head_sha }}
+      artifact_run_id: ${{ github.event.workflow_run.id }}
+      pr_key: ${{ needs.meta.outputs.pr_number }}
+      pr_branch: ${{ needs.meta.outputs.head_ref }}
+      pr_base: ${{ needs.meta.outputs.base_ref }}
+      ignore_scripts: true
+    secrets: inherit
+
+  status:
+    needs: [meta, app-sec]
+    if: always() && needs.meta.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report app-sec result to the PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const state = '${{ needs.app-sec.result }}' === 'success' ? 'success' : 'failure';
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.meta.outputs.head_sha }}',
+              state,
+              context: 'app-sec (fork)',
+              description: state === 'success' ? 'App-sec passed' : 'App-sec failed',
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });

--- a/.github/workflows/app-sec-template.yml
+++ b/.github/workflows/app-sec-template.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
 
       - name: Install dependencies
         run: ${{ inputs.ignore_scripts && 'npm ci --ignore-scripts' || 'npm install' }}

--- a/.github/workflows/app-sec-template.yml
+++ b/.github/workflows/app-sec-template.yml
@@ -6,6 +6,43 @@ on:
       github_ref:
         required: true
         type: string
+      # Optional: analyze code from a different repo/ref. Used by the fork
+      # workflow_run path to check out the fork PR head. Defaults preserve the
+      # original in-repo (pull_request) behaviour.
+      checkout_repository:
+        required: false
+        type: string
+        default: ""
+      checkout_ref:
+        required: false
+        type: string
+        default: ""
+      # Optional: download the lcov artifact from a different run (the CI run
+      # that triggered a workflow_run). Empty = current run.
+      artifact_run_id:
+        required: false
+        type: string
+        default: ""
+      # Optional SonarQube PR-analysis context. When empty, the scan action
+      # auto-detects PR info from the pull_request event.
+      pr_key:
+        required: false
+        type: string
+        default: ""
+      pr_branch:
+        required: false
+        type: string
+        default: ""
+      pr_base:
+        required: false
+        type: string
+        default: ""
+      # Fork code is untrusted: skip npm lifecycle scripts to avoid arbitrary
+      # code execution while secrets are in scope.
+      ignore_scripts:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   app-sec:
@@ -14,6 +51,8 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
         with:
+          repository: ${{ inputs.checkout_repository || github.repository }}
+          ref: ${{ inputs.checkout_ref || github.sha }}
           fetch-depth: 0
 
       - name: Install Node.js
@@ -22,7 +61,7 @@ jobs:
           node-version: 20.x
 
       - name: Install dependencies
-        run: npm install
+        run: ${{ inputs.ignore_scripts && 'npm ci --ignore-scripts' || 'npm install' }}
 
       - name: get-npm-version
         id: package-version
@@ -32,8 +71,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: lcov
+          run-id: ${{ inputs.artifact_run_id || github.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: SonarCloud Scan
+      - name: SonarQube Scan
         uses: sonarsource/sonarqube-scan-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -41,6 +82,7 @@ jobs:
         with:
           args: >
             -Dsonar.projectVersion=${{ steps.package-version.outputs.current-version}}
+            ${{ inputs.pr_key && format('-Dsonar.pullrequest.key={0} -Dsonar.pullrequest.branch={1} -Dsonar.pullrequest.base={2}', inputs.pr_key, inputs.pr_branch, inputs.pr_base) || '' }}
 
       - name: Sonarqube Quality Gate Check
         id: sonarqube-quality-gate-check

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - run: npm ci
       - run: xvfb-run -a npm run coverage
         if: runner.os == 'Linux'

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -52,6 +52,37 @@ jobs:
           path: coverage-reports/lcov.info
           retention-days: 1
 
+      # Fork PRs get no secrets from the pull_request event, so the inline
+      # app-sec job below is skipped for them. Capture the PR context here so
+      # the secrets-enabled app-sec-forks.yml (workflow_run) can re-run app-sec.
+      # Values go via env (not string-interpolated into the script) to avoid
+      # shell injection from attacker-controlled ref/branch names.
+      - name: Write PR metadata for fork app-sec
+        if: runner.os == 'Linux' && github.event.pull_request.head.repo.fork
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          mkdir -p pr-meta
+          {
+            echo "PR_NUMBER=${PR_NUMBER}"
+            echo "PR_HEAD_REPO=${PR_HEAD_REPO}"
+            echo "PR_HEAD_SHA=${PR_HEAD_SHA}"
+            echo "PR_HEAD_REF=${PR_HEAD_REF}"
+            echo "PR_BASE_REF=${PR_BASE_REF}"
+          } > pr-meta/pr.env
+
+      - name: Upload PR metadata for fork app-sec
+        if: runner.os == 'Linux' && github.event.pull_request.head.repo.fork
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-meta
+          path: pr-meta/pr.env
+          retention-days: 1
+
   test-q:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - run: npm ci
       - run: xvfb-run -a npm run coverage
         if: runner.os == 'Linux'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,37 @@ jobs:
           name: lcov
           path: coverage-reports/lcov.info
           retention-days: 1
+
+      # Fork PRs get no secrets from the pull_request event, so the inline
+      # app-sec job below is skipped for them. Capture the PR context here so
+      # the secrets-enabled app-sec-forks.yml (workflow_run) can re-run app-sec.
+      # Values go via env (not string-interpolated into the script) to avoid
+      # shell injection from attacker-controlled ref/branch names.
+      - name: Write PR metadata for fork app-sec
+        if: runner.os == 'Linux' && github.event.pull_request.head.repo.fork
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          mkdir -p pr-meta
+          {
+            echo "PR_NUMBER=${PR_NUMBER}"
+            echo "PR_HEAD_REPO=${PR_HEAD_REPO}"
+            echo "PR_HEAD_SHA=${PR_HEAD_SHA}"
+            echo "PR_HEAD_REF=${PR_HEAD_REF}"
+            echo "PR_BASE_REF=${PR_BASE_REF}"
+          } > pr-meta/pr.env
+
+      - name: Upload PR metadata for fork app-sec
+        if: runner.os == 'Linux' && github.event.pull_request.head.repo.fork
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-meta
+          path: pr-meta/pr.env
+          retention-days: 1
   test-q:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/prod_release.yml
+++ b/.github/workflows/prod_release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Install dependencies
         run: npm ci --include=dev
       - name: Build VSIX file
@@ -108,7 +108,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Install dependencies
         run: npm ci --include=dev
       - name: Publish to VSCode Marketplace

--- a/.github/workflows/q-api.yml
+++ b/.github/workflows/q-api.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - run: node build-api.js
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Install dependencies
         run: npm ci --include=dev
       - name: Build VSIX file

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/ws": "8.18.1",
         "@vscode/extension-telemetry": "1.4.0",
         "@vscode/python-extension": "1.0.6",
-        "@vscode/test-electron": "2.5.2",
+        "@vscode/test-electron": "3.1.0",
         "@vscode/vsce": "3.9.2",
         "axios": "1.16.1",
         "c8": "11.0.0",
@@ -2610,9 +2610,9 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2623,7 +2623,7 @@
         "semver": "^7.6.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@vscode/vsce": {

--- a/package.json
+++ b/package.json
@@ -1260,7 +1260,7 @@
     "@types/ws": "8.18.1",
     "@vscode/extension-telemetry": "1.4.0",
     "@vscode/python-extension": "1.0.6",
-    "@vscode/test-electron": "2.5.2",
+    "@vscode/test-electron": "3.1.0",
     "@vscode/vsce": "3.9.2",
     "axios": "1.16.1",
     "c8": "11.0.0",


### PR DESCRIPTION
Fork PRs get no secrets from the pull_request event, so the inline app-sec job is skipped for them. Add a secrets-enabled workflow_run workflow that re-runs the full app-sec suite for fork PRs:

- app-sec-template.yml: add optional checkout repo/ref, cross-run artifact download, SonarQube PR-analysis params, and ignore-scripts inputs (defaults preserve existing in-repo behaviour).
- dev.yml / main.yml: upload PR metadata artifact for fork PRs.
- app-sec-forks.yml: new workflow_run trigger, fork-only, installs deps with --ignore-scripts, and reports the result back to the PR as a commit status.

