### PR TITLE
CI: skip test-q on fork pull requests

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -54,6 +54,9 @@ jobs:
 
   test-q:
     runs-on: ubuntu-latest
+    # Needs the private GitLab registry credentials and a kdb+ license, neither
+    # of which is available to pull requests from forks.
+    if: "! github.event.pull_request.head.repo.fork"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,9 @@ jobs:
           retention-days: 1
   test-q:
     runs-on: ubuntu-latest
+    # Needs the private GitLab registry credentials and a kdb+ license, neither
+    # of which is available to pull requests from forks.
+    if: "! github.event.pull_request.head.repo.fork"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/ws": "8.18.1",
         "@vscode/extension-telemetry": "1.4.0",
         "@vscode/python-extension": "1.0.6",
-        "@vscode/test-electron": "2.5.2",
+        "@vscode/test-electron": "3.1.0",
         "@vscode/vsce": "3.9.2",
         "axios": "1.16.1",
         "c8": "11.0.0",
@@ -2610,9 +2610,9 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2623,7 +2623,7 @@
         "semver": "^7.6.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@vscode/vsce": {

--- a/package.json
+++ b/package.json
@@ -1260,7 +1260,7 @@
     "@types/ws": "8.18.1",
     "@vscode/extension-telemetry": "1.4.0",
     "@vscode/python-extension": "1.0.6",
-    "@vscode/test-electron": "2.5.2",
+    "@vscode/test-electron": "3.1.0",
     "@vscode/vsce": "3.9.2",
     "axios": "1.16.1",
     "c8": "11.0.0",


### PR DESCRIPTION
### Changes introduced by this PR

-  Skip test-q on fork pull requests since test-q needs two secrets a fork PR can never have like the appsec.
- Also updated test electron.
