### PR TITLE
KXI-72922 Fixed a bug where evaluating a single character Python query would throw a type error, since it was getting incorrectly enlisted

### DIFF
--- a/resources/q/evaluatePy.q
+++ b/resources/q/evaluatePy.q
@@ -372,7 +372,7 @@
         }";
 
     removeExtraIndents:{[code]
-        if[1 ~ count code; code: enlist code];
+        if[-10h ~ type code; code: enlist code];
         inStrings:$[(count ss[code;"'''"])or count ss[code;"\"\"\""];
             1+raze{x+til y-x}./:.pykx.qeval["_kx_execution_context['pystruct_find_strings']"]code;
             ()];

--- a/test/q/tests/evaluatePy.quke
+++ b/test/q/tests/evaluatePy.quke
@@ -104,6 +104,10 @@ feature evaluatePy 1
             .qu.compare[
                 .test.evaluatePy["text"; "1+2"];
                 .test.wrap "3\n"]
+        expect single character expressions to be run correctly
+            .qu.compare[
+                .test.evaluatePy["text"; "1"];
+                .test.wrap "1\n"]
         expect statements to return an empty string
             .qu.compare[
                 .test.evaluatePy["text"; "def axedi_test_fn(x):\n    return 1 + x"];


### PR DESCRIPTION
[KXI-72922](https://kxl.atlassian.net/browse/KXI-72922) Executing a single character in Python fails with a type error

### Changes introduced by this PR
A single character Python query, such as `1`, would cause a type error, as it was being incorrectly enlisted by the code that was meant to turn char atoms into strings. This has been fixed so it checks the type instead of the length before enlisting, bringing it into sync with what happens in the framework version of the code.
