### PR TITLE
Console: fit datasource tables to the console width by char

### DIFF
--- a/src/classes/connectionConsole.ts
+++ b/src/classes/connectionConsole.ts
@@ -55,8 +55,8 @@ export class ConnectionConsole {
   private buffer?: string[] = [];
   private _exited = false;
   // How wide the terminal is, as VS Code reports it — 0 until it is opened and
-  // measured. Read by whoever formats a result, so a table can be cut to whole
-  // columns before it gets here (see convertRowsToConsole).
+  // measured. Read by whoever formats a result, so a table can be cut to the
+  // width before it gets here (see convertRowsToConsole).
   private _columns = 0;
   // True while we are tearing the console down programmatically (dispose), so
   // the pty close handler can tell a user-initiated close apart from our own.

--- a/src/classes/connectionConsole.ts
+++ b/src/classes/connectionConsole.ts
@@ -54,9 +54,10 @@ export class ConnectionConsole {
   // in open() and then left undefined so writes go straight to the emitter.
   private buffer?: string[] = [];
   private _exited = false;
-  // How wide the terminal is, as VS Code reports it. A result row wider than
-  // this wraps, and a wrapped table is unreadable — see appendResult.
-  private columns = 0;
+  // How wide the terminal is, as VS Code reports it — 0 until it is opened and
+  // measured. Read by whoever formats a result, so a table can be cut to whole
+  // columns before it gets here (see convertRowsToConsole).
+  private _columns = 0;
   // True while we are tearing the console down programmatically (dispose), so
   // the pty close handler can tell a user-initiated close apart from our own.
   private disposing = false;
@@ -79,7 +80,7 @@ export class ConnectionConsole {
         open: this.open.bind(this),
         close: this.close.bind(this),
         setDimensions: (dimensions: vscode.TerminalDimensions) => {
-          this.columns = dimensions.columns;
+          this._columns = dimensions.columns;
         },
         handleInput: this.handleInput.bind(this),
       },
@@ -92,6 +93,10 @@ export class ConnectionConsole {
 
   get exited(): boolean {
     return this._exited;
+  }
+
+  get columns(): number {
+    return this._columns;
   }
 
   private normalize(text: string): string {
@@ -145,27 +150,14 @@ export class ConnectionConsole {
   }
 
   /**
-   * Writes the lines of a result, each cut to the width of the terminal rather
-   * than left to wrap — a table whose rows wrap loses the columns that make it
-   * a table. A cut line ends in `..`, as a q console marks one.
+   * Writes the lines of a result. Nothing is cut here: the process that ran the
+   * query renders its own console text to its `\c`, and a datasource result is
+   * fitted to {@link columns} by the formatter that builds its table.
    */
   appendResult(lines: string[]): void {
     for (const line of lines) {
-      this.appendLine(this.fit(line));
+      this.appendLine(line);
     }
-  }
-
-  private fit(line: string): string {
-    // Escape sequences are not characters on screen; a line carrying them is
-    // ours (a banner, a hint) and short enough to leave alone.
-    if (
-      !this.columns ||
-      line.includes("\u001b") ||
-      line.length <= this.columns
-    ) {
-      return line;
-    }
-    return line.slice(0, Math.max(0, this.columns - 2)) + "..";
   }
 
   clear(): void {

--- a/src/commands/dataSourceCommand.ts
+++ b/src/commands/dataSourceCommand.ts
@@ -241,8 +241,13 @@ export async function runDataSource(
           res = res.errorMsg ? res.errorMsg : res.error;
         }
 
+        // Fit the table to the connection's console, which wraps what does not
+        // fit; 0 (no console open) leaves it unlimited.
         const rowData = res.columns
-          ? convertRows(updatedExtractRowData(res))
+          ? convertRows(
+              updatedExtractRowData(res),
+              ext.connectionConsoles.get(connLabel)?.columns ?? 0,
+            )
           : res;
 
         await writeQueryResultsToConsole(

--- a/src/utils/executionConsole.ts
+++ b/src/utils/executionConsole.ts
@@ -33,7 +33,7 @@ const logger = "executionConsole";
 // terminal (when one exists for the connLabel) or the shared fallback channel.
 interface ConsoleSink {
   appendLine: (value: string) => void;
-  // Result lines, which a terminal sink cuts to its width instead of wrapping.
+  // The lines of a result, kept apart from the banner lines around them.
   appendResult: (lines: string[]) => void;
   reveal: () => void;
 }

--- a/src/utils/queryUtils.ts
+++ b/src/utils/queryUtils.ts
@@ -232,7 +232,7 @@ export function getSQLWrapper(query: string): string {
   return `s)${query.replace(/(?:\r\n|\n)/g, " ")}`;
 }
 
-export function convertRows(rows: any[]): any {
+export function convertRows(rows: any[], width = 0): any {
   if (rows.length === 0) {
     return [];
   }
@@ -249,7 +249,28 @@ export function convertRows(rows: any[]): any {
     });
     result.push(values.join("#$#;#$#"));
   }
-  return convertRowsToConsole(result).join("\n") + "\n\n";
+  return convertRowsToConsole(result, width).join("\n") + "\n\n";
+}
+
+// Marks a table the console could not show in full, as a q console marks one.
+const CUT = "..";
+
+// How many whole columns fit in the given width. A table that loses columns is
+// still a table; one whose rows wrap, or get sliced mid-cell, is not. A width
+// of 0 means no limit — the shared output channel scrolls horizontally, where
+// a terminal only wraps.
+function fitColumns(counters: number[], width: number): number {
+  const budget = width - CUT.length;
+  let used = 0;
+  let keep = 0;
+  for (const counter of counters) {
+    if (used + counter > budget) {
+      break;
+    }
+    used += counter;
+    keep++;
+  }
+  return Math.max(1, keep);
 }
 
 // A cell that arrives with newlines in it — a nested list, rendered down the
@@ -269,7 +290,7 @@ function flatten(value: string) {
     .trimEnd();
 }
 
-export function convertRowsToConsole(rows: string[]): string[] {
+export function convertRowsToConsole(rows: string[], width = 0): string[] {
   if (rows.length === 0) {
     return [];
   }
@@ -307,12 +328,19 @@ export function convertRowsToConsole(rows: string[]): string[] {
     });
   });
 
-  const result = vector.map((row) => row.join(""));
-
   const totalCount = columnCounters.reduce((sum, count) => sum + count, 0);
-  const totalCounter = "-".repeat(totalCount);
+  const cut = width > 0 && totalCount > width;
+  const keep = cut ? fitColumns(columnCounters, width) : columnCounters.length;
+
+  const result = vector.map((row) => {
+    const line = row.slice(0, keep).join("");
+    // The single kept column can still be wider than the width on its own,
+    // which is the one case a cell is cut rather than a column dropped.
+    return cut ? line.slice(0, Math.max(0, width - CUT.length)) + CUT : line;
+  });
+
   if (haveHeader) {
-    result.splice(1, 0, totalCounter);
+    result.splice(1, 0, "-".repeat(result[0].length));
   }
 
   return result;

--- a/src/utils/queryUtils.ts
+++ b/src/utils/queryUtils.ts
@@ -252,25 +252,17 @@ export function convertRows(rows: any[], width = 0): any {
   return convertRowsToConsole(result, width).join("\n") + "\n\n";
 }
 
-// Marks a table the console could not show in full, as a q console marks one.
+// Marks a line the console could not show in full, as a q console marks one.
 const CUT = "..";
 
-// How many whole columns fit in the given width. A table that loses columns is
-// still a table; one whose rows wrap, or get sliced mid-cell, is not. A width
+// Cuts a line to the given width, as a q console cuts one to its `\c`. A width
 // of 0 means no limit — the shared output channel scrolls horizontally, where
-// a terminal only wraps.
-function fitColumns(counters: number[], width: number): number {
-  const budget = width - CUT.length;
-  let used = 0;
-  let keep = 0;
-  for (const counter of counters) {
-    if (used + counter > budget) {
-      break;
-    }
-    used += counter;
-    keep++;
+// a terminal only wraps, and a wrapped table is no longer a table.
+function fit(line: string, width: number): string {
+  if (!width || line.length <= width) {
+    return line;
   }
-  return Math.max(1, keep);
+  return line.slice(0, Math.max(0, width - CUT.length)) + CUT;
 }
 
 // A cell that arrives with newlines in it — a nested list, rendered down the
@@ -328,16 +320,7 @@ export function convertRowsToConsole(rows: string[], width = 0): string[] {
     });
   });
 
-  const totalCount = columnCounters.reduce((sum, count) => sum + count, 0);
-  const cut = width > 0 && totalCount > width;
-  const keep = cut ? fitColumns(columnCounters, width) : columnCounters.length;
-
-  const result = vector.map((row) => {
-    const line = row.slice(0, keep).join("");
-    // The single kept column can still be wider than the width on its own,
-    // which is the one case a cell is cut rather than a column dropped.
-    return cut ? line.slice(0, Math.max(0, width - CUT.length)) + CUT : line;
-  });
+  const result = vector.map((row) => fit(row.join(""), width));
 
   if (haveHeader) {
     result.splice(1, 0, "-".repeat(result[0].length));

--- a/test/suite/classes/connectionConsole.test.ts
+++ b/test/suite/classes/connectionConsole.test.ts
@@ -46,40 +46,20 @@ describe("ConnectionConsole", () => {
     return console;
   }
 
-  it("should leave a result that fits alone", () => {
-    const console = open(40);
-    console.appendResult(["a  b  ", "------", "1  2  "]);
-    assert.deepStrictEqual(
-      written.map((line) => line.replace(/\r\n/g, "")),
-      ["a  b  ", "------", "1  2  "],
-    );
-  });
-
-  it("should cut a row that would wrap", () => {
+  it("should write the lines of a result as they are", () => {
     const console = open(10);
-    console.appendResult(["0123456789abcdef"]);
+    console.appendResult(["a  b  ", "------", "0123456789abcdef"]);
     assert.deepStrictEqual(
       written.map((line) => line.replace(/\r\n/g, "")),
-      ["01234567.."],
+      ["a  b  ", "------", "0123456789abcdef"],
     );
   });
 
-  it("should leave every row alone until the width is known", () => {
-    const console = open(0);
-    console.appendResult(["0123456789abcdef"]);
-    assert.deepStrictEqual(
-      written.map((line) => line.replace(/\r\n/g, "")),
-      ["0123456789abcdef"],
-    );
+  it("should report the width the terminal was given", () => {
+    assert.strictEqual(open(40).columns, 40);
   });
 
-  it("should not cut a line carrying escape sequences", () => {
-    const console = open(10);
-    const line = "[1mheading that is far too wide[0m";
-    console.appendResult([line]);
-    assert.deepStrictEqual(
-      written.map((value) => value.replace(/\r\n/g, "")),
-      [line],
-    );
+  it("should report no width until the terminal is measured", () => {
+    assert.strictEqual(open(0).columns, 0);
   });
 });

--- a/test/suite/utils/queryUtils.test.ts
+++ b/test/suite/utils/queryUtils.test.ts
@@ -121,6 +121,30 @@ describe("queryUtils", () => {
       ]);
     });
 
+    it("should drop the columns that do not fit the width", () => {
+      const rows = [
+        "aa#$#;header;#$#bb#$#;header;#$#cc",
+        "11#$#;#$#22#$#;#$#33",
+      ];
+      const result = queryUtils.convertRowsToConsole(rows, 10);
+
+      assert.deepEqual(result, ["aa  bb  ..", "----------", "11  22  .."]);
+    });
+
+    it("should keep every column when they all fit the width", () => {
+      const rows = ["a#$#;header;#$#b", "1#$#;#$#2"];
+      const result = queryUtils.convertRowsToConsole(rows, 40);
+
+      assert.deepEqual(result, ["a  b  ", "------", "1  2  "]);
+    });
+
+    it("should cut the cells of a single column too wide to fit", () => {
+      const rows = ["header#$#;header;#$#", "0123456789abcdef"];
+      const result = queryUtils.convertRowsToConsole(rows, 10);
+
+      assert.deepEqual(result, ["header  ..", "----------", "01234567.."]);
+    });
+
     it("should keep a row with newlines in it on one line", () => {
       const rows = ["a#$#;header;#$#b", "a1\na2#$#;#$#b1\nb2", "3#$#;#$#4"];
       const expectedRes = [

--- a/test/suite/utils/queryUtils.test.ts
+++ b/test/suite/utils/queryUtils.test.ts
@@ -121,28 +121,32 @@ describe("queryUtils", () => {
       ]);
     });
 
-    it("should drop the columns that do not fit the width", () => {
+    it("should cut a row that does not fit the width", () => {
       const rows = [
         "aa#$#;header;#$#bb#$#;header;#$#cc",
         "11#$#;#$#22#$#;#$#33",
       ];
-      const result = queryUtils.convertRowsToConsole(rows, 10);
+      const result = queryUtils.convertRowsToConsole(rows, 11);
 
-      assert.deepEqual(result, ["aa  bb  ..", "----------", "11  22  .."]);
+      assert.deepEqual(result, ["aa  bb  c..", "-----------", "11  22  3.."]);
     });
 
-    it("should keep every column when they all fit the width", () => {
+    it("should leave a row that fits the width alone", () => {
       const rows = ["a#$#;header;#$#b", "1#$#;#$#2"];
       const result = queryUtils.convertRowsToConsole(rows, 40);
 
       assert.deepEqual(result, ["a  b  ", "------", "1  2  "]);
     });
 
-    it("should cut the cells of a single column too wide to fit", () => {
-      const rows = ["header#$#;header;#$#", "0123456789abcdef"];
-      const result = queryUtils.convertRowsToConsole(rows, 10);
+    it("should keep the start of a column too wide to fit", () => {
+      const rows = ["id#$#;header;#$#text", "1#$#;#$#0123456789abcdef"];
+      const result = queryUtils.convertRowsToConsole(rows, 12);
 
-      assert.deepEqual(result, ["header  ..", "----------", "01234567.."]);
+      assert.deepEqual(result, [
+        "id  text  ..",
+        "------------",
+        "1   012345..",
+      ]);
     });
 
     it("should keep a row with newlines in it on one line", () => {


### PR DESCRIPTION
### Changes introduced by this PR

- Datasource tables written to a connection's output console are now fitted to
  the console width by char.
- Console text from a q process is written as it arrives, since the process
  already fits it to its own `\c`.
