### PR TITLE
Tests: broaden the end to end suite

### DIFF
--- a/docs/developer/development.md
+++ b/docs/developer/development.md
@@ -89,10 +89,31 @@ what it is sent, which is what the tests assert on:
   settings on it and a test can stand up an older instance by changing them.
 - the browser the OAuth code flow opens, replaced in `insights.ts` by a
   function that walks the authorization redirect back to the extension's own
-  local server. It is the only stand-in that replaces a VS Code API rather than
-  a process, and it exists because there is no one in a test window to open the
+  local server. It exists because there is no one in a test window to open the
   URL — the code flow, the token request and the certificate handling all still
   run for real.
+- the person a notification is addressed to, replaced in `prompt.ts`. A
+  notification's buttons are drawn by the workbench and no API presses one, so
+  a command that asks before it acts could otherwise not be driven to either
+  answer. Every notification is recorded, and one is answered only when a test
+  has said what to answer it with.
+
+The last two replace a VS Code API rather than a process, and both stand in for
+the user rather than for anything the extension talks to.
+
+What a tree view draws is the one thing these tests cannot reach: VS Code
+exposes no API for another extension's tree items, and the window loads the
+bundled extension, so a test cannot reach the providers either. Tree contents
+are covered in `test/suite` instead; what a tree item's command does when it is
+run is still driven from here, with the item the tree would hand it.
+
+The workspace also turns off everything the workbench would otherwise put in
+front of a test: `files.simpleDialog.enable` replaces the system file dialog
+with a quick pick a test can accept, and the `explorer.confirm*` settings drop
+the confirmations the explorer raises before it deletes or moves a file.
+`window.dialogStyle` is deliberately not among them — it is application scoped,
+so a workspace file cannot set it, and modal messages are answered through
+`prompt.ts` rather than by their style.
 
 Both suites can be debugged with the `E2E Tests` and `E2E Test Selected File`
 targets in the run and debug tab.

--- a/docs/developer/end-to-end-coverage.md
+++ b/docs/developer/end-to-end-coverage.md
@@ -1,0 +1,52 @@
+---
+type: Developer Note
+title: What the End to End Suite Covers
+description: A short map of what npm run test:e2e asserts, and what it cannot reach.
+tags: [kdb, vscode, testing, e2e]
+timestamp: 2026-08-21
+---
+
+# What the End to End Suite Covers
+
+`npm run test:e2e` drives the extension in a real VS Code window against
+stand-in processes. See [Development](development.md) for how it is wired up.
+This page is the map of what it actually asserts.
+
+## Covered
+
+- **Running code** — q, SQL and Python, from a file, a workbook, a `.quke` file
+  and a notebook, on the REPL, a kdb+ connection and an Insights connection.
+  Whole file, selection, current line, and the block under the cursor.
+- **Where code runs** — the file's assigned connection, the last focused KX
+  terminal, and the REPL by default. Files outside the workspace included.
+- **The REPL** — typing at the prompt, recall, Ctrl+C, Ctrl+D, Ctrl+L, dropping
+  a file on it, and several REPLs across folders.
+- **Connecting** — the kdb+ handshake with and without credentials, the
+  Insights OAuth code flow over a self-signed certificate, and being offered a
+  connection when the file's one is not connected.
+- **Insights by version** — which endpoints and request bodies each instance
+  from 1.10 to 1.18 gets, with query environments on and off.
+- **The scratchpad** — the log websocket, resetting it, and the execution
+  timeout each request carries.
+- **Results** — the grid, paging, structured text, the console, and the CSV
+  export.
+- **The q language** — definition, references, call hierarchy, folding,
+  completion, selection expand and the parameter cache, against the real
+  language server.
+- **Panels** — the welcome page and the new connection form, driven as real
+  components.
+
+## Not covered
+
+- **Anything a tree view draws.** VS Code exposes no API for another
+  extension's tree items, so connection categories, query history entries and
+  their icons and colours are asserted in `test/suite` instead. What a tree
+  item's command *does* is still covered here.
+- **Datasources and UDAs** — neither the editor nor the queries they send.
+- **Importing and exporting connections.** The workspace turns the system file
+  dialog into a quick pick, which a test can accept — but only the `defaultUri`
+  it was opened on, since keystrokes do not reach it. These two commands pass
+  no `defaultUri`, so there is nothing to accept.
+- **The output channel**, which cannot be read back.
+- **Windows**, where the REPL spawns q through `cmd.exe` and cannot run the
+  stand-in.

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -15,6 +15,7 @@ Architecture and contributor notes for the kdb VS Code extension. See also the
 > <https://code.kx.com/vscode/>.
 
 - [Development](development.md) — setup, recommended extensions, scripts, debugging, releasing.
+- [What the End to End Suite Covers](end-to-end-coverage.md) — the map of what `test:e2e` asserts, and what it cannot reach.
 - [Log, Telemetry and User Notifications](log-telemetry-and-user-notifications.md) — the single notification entry point.
 - [Progress Notifications](progress-notifications.md) — creating progress notifications.
 - [Query Execution Call Hierarchy](query-execution-call-hierarchy.md) — file types, actions and their entry points.

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -198,7 +198,18 @@ export namespace ext {
     // "Namespaces", removed to investigate
   ];
 
-  export const qNamespaceFilters = [".q", ".Q", ".h", ".z", ".o", ".j", ".m"];
+  // The namespaces a process keeps to itself, which are its own business
+  // rather than the user's and so are left out of the listing.
+  export const qNamespaceFilters = [
+    ".q",
+    ".Q",
+    ".h",
+    ".z",
+    ".o",
+    ".j",
+    ".m",
+    ".s",
+  ];
 
   export const constants = {
     names: [

--- a/src/services/kdbTreeService.ts
+++ b/src/services/kdbTreeService.ts
@@ -55,7 +55,13 @@ export class KdbTreeService {
     const serverObjects = await conn.loadServerObjects();
     if (serverObjects !== undefined) {
       const funcs = serverObjects.filter((value) => {
-        return value.typeNum === 100 && !value.isNs && value.namespace === ns
+        // Everything callable, not only lambdas: 100 through 112 covers
+        // primitives, operators and iterators as well as the projections and
+        // compositions a lambda is partially applied into.
+        return value.typeNum >= 100 &&
+          value.typeNum <= 112 &&
+          !value.isNs &&
+          value.namespace === ns
           ? value
           : undefined;
       });

--- a/test/e2e/connect.test.ts
+++ b/test/e2e/connect.test.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 1998-2026 KX Systems Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+import * as assert from "node:assert";
+import * as fs from "node:fs";
+import * as vscode from "vscode";
+
+import { activate, file, focus, settle, until } from "./utils";
+import { ensure, labelOf } from "./utils/connection";
+import { answer, clear, raised, untilRaised } from "./utils/prompt";
+import { FakeQ } from "./utils/qserver";
+
+/**
+ * Running a file whose connection is declared but not connected.
+ *
+ * The file names its connection in kdb.connectionMap, so it neither falls back
+ * to the REPL nor to whatever is active: the run stops and asks. Answering is
+ * what the notification stand-in is for — the buttons are drawn by the
+ * workbench and no API presses one.
+ */
+
+// A stand-in of its own, on its own port, so nothing else in the window has
+// connected to it: these are about a connection that is declared and idle.
+const SERVER = {
+  serverName: "127.0.0.1",
+  serverPort: "25100",
+  serverAlias: "TESTOFFER",
+  auth: false,
+  tls: false,
+  managed: false,
+};
+
+const CONNECTION = labelOf(SERVER);
+const OFFER = "would you like to connect?";
+
+// Assigned to TESTOFFER in the workspace settings.
+const QUERY_FILE = file("offer.q");
+const QUERY = '"OFFER_TO_CONNECT"';
+
+const server = new FakeQ();
+
+async function runFile() {
+  await focus(QUERY_FILE);
+  await vscode.commands.executeCommand("kdb.execute.fileQuery");
+}
+
+describe("Running a file whose connection is not connected", () => {
+  before(async () => {
+    await activate();
+    fs.writeFileSync(QUERY_FILE.fsPath, `${QUERY}\n`);
+
+    await server.listen(Number(SERVER.serverPort));
+    // Declared the way the UI declares it, and deliberately not dialled.
+    await ensure(SERVER);
+  });
+
+  beforeEach(() => clear());
+
+  after(async () => {
+    fs.rmSync(QUERY_FILE.fsPath, { force: true });
+    await vscode.commands.executeCommand(
+      "kdb.connections.disconnect",
+      CONNECTION,
+    );
+    await server.close();
+    await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+  });
+
+  it("asks rather than running the file somewhere else", async () => {
+    answer(OFFER, "Cancel");
+    await runFile();
+
+    await untilRaised(OFFER);
+    const [asked] = raised(OFFER);
+    assert.strictEqual(asked.kind, "warning");
+    assert.ok(
+      asked.message.includes(SERVER.serverAlias),
+      `the connection was not named:\n${asked.message}`,
+    );
+    assert.deepStrictEqual(asked.buttons, ["Connect", "Cancel"]);
+  });
+
+  it("runs nothing when the offer is declined", async () => {
+    answer(OFFER, "Cancel");
+    await runFile();
+
+    await untilRaised(OFFER);
+    await settle();
+
+    assert.strictEqual(server.connections, 0, "it connected anyway");
+  });
+
+  it("connects and runs the file when the offer is accepted", async () => {
+    answer(OFFER, "Connect");
+    await runFile();
+
+    await until(
+      () =>
+        server.queries().some((request) => request.args?.code?.includes(QUERY)),
+      `the query to reach ${CONNECTION} (sent ${server
+        .queries()
+        .map((request) => request.args?.code)
+        .join(", ")})`,
+    );
+  });
+
+  it("stops asking once it is connected", async () => {
+    await runFile();
+
+    await until(
+      () => server.queries().length > 1,
+      "the file to run a second time",
+    );
+    assert.deepStrictEqual(raised(OFFER), []);
+  });
+});

--- a/test/e2e/csv.test.ts
+++ b/test/e2e/csv.test.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 1998-2026 KX Systems Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+import * as assert from "node:assert";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as vscode from "vscode";
+
+import { activate, file, focus, until, WORKSPACE } from "./utils";
+import { kdb, start } from "./utils/connection";
+import { structuredText } from "./utils/fixtures";
+import { clear, raised } from "./utils/prompt";
+
+/**
+ * Exporting what the results view is showing.
+ *
+ * The export writes a `results-<timestamp>.csv` into the first workspace
+ * folder rather than asking where to put it, so the file it wrote is what
+ * these read back. What matters is the quoting: a cell holding a list or a
+ * string carries the comma that would otherwise end it early, and a quote that
+ * would otherwise end the field.
+ */
+
+const QUERY_FILE = file("csv.q");
+
+// A row whose cells are the two the export has to survive: a list, which is
+// rendered into the cell comma separated, and a string carrying both a comma
+// and a quote of its own.
+const ROW = {
+  sym: "AAPL",
+  tags: "alpha,beta,gamma",
+  note: 'say "hi", twice',
+};
+
+// Every results file sitting in the workspace, newest last.
+const exported = () =>
+  fs
+    .readdirSync(WORKSPACE)
+    .filter((name) => /^results-\d+\.csv$/.test(name))
+    .sort();
+
+function discard() {
+  for (const name of exported()) {
+    fs.rmSync(path.join(WORKSPACE, name), { force: true });
+  }
+}
+
+describe("Exporting the results as CSV", () => {
+  let lines: string[] = [];
+
+  before(async () => {
+    await activate();
+    await start();
+
+    // What the stand-in answers the query with, in the shape a process answers
+    // a results view query in.
+    kdb.data = structuredText([ROW]);
+    fs.writeFileSync(QUERY_FILE.fsPath, `${ROW.sym}\n`);
+    discard();
+    clear();
+
+    // The view only renders once it has been resolved, and only holds
+    // something to export once a query has been rendered into it.
+    await vscode.commands.executeCommand("kdb.results.destination.view");
+    await vscode.commands.executeCommand("kdb-results.focus");
+    await focus(QUERY_FILE);
+    kdb.clear();
+    await vscode.commands.executeCommand("kdb.execute.fileQuery");
+    await until(() => kdb.queries().length > 0, "the query to run");
+
+    // The results are rendered after the command that filled them resolves, so
+    // the export is asked for until there is something to export.
+    for (let attempt = 0; attempt < 100; attempt++) {
+      clear();
+      await vscode.commands.executeCommand("kdb.resultsPanel.export.csv");
+      if (exported().length > 0) {
+        break;
+      }
+      assert.deepStrictEqual(
+        raised("Open a folder to export results"),
+        [],
+        "the workspace folder was not found",
+      );
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    const written = exported();
+    assert.strictEqual(
+      written.length,
+      1,
+      `nothing was exported: ${raised("export").map((n) => n.message)}`,
+    );
+    lines = fs
+      .readFileSync(path.join(WORKSPACE, written[0]), "utf8")
+      .split("\n");
+
+    // The export opens what it wrote, and does not wait for the editor before
+    // it resolves. Letting that finish is what makes the file safe to delete.
+    await until(
+      () =>
+        vscode.window.visibleTextEditors.some((editor) =>
+          editor.document.uri.fsPath.endsWith(written[0]),
+        ),
+      "the exported file to be opened",
+    );
+    await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+  });
+
+  after(async () => {
+    kdb.data = "OK";
+    fs.rmSync(QUERY_FILE.fsPath, { force: true });
+    discard();
+    await vscode.commands.executeCommand("kdb.results.destination.terminal");
+    await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+  });
+
+  it("writes a header naming every column the view is showing", () => {
+    assert.strictEqual(lines[0], '"index","sym","tags","note"');
+  });
+
+  it("quotes a cell holding a list, so its commas do not end the field", () => {
+    assert.ok(
+      lines[1].includes(`"${ROW.tags}"`),
+      `the list was not quoted:\n${lines[1]}`,
+    );
+  });
+
+  it("doubles the quotes inside a string rather than ending the field", () => {
+    assert.ok(
+      lines[1].includes('"say ""hi"", twice"'),
+      `the string was not escaped:\n${lines[1]}`,
+    );
+  });
+
+  it("writes one row, numbered, with every cell quoted", () => {
+    assert.strictEqual(
+      lines[1],
+      `"1","${ROW.sym}","${ROW.tags}","say ""hi"", twice"`,
+    );
+    assert.deepStrictEqual(lines.slice(2), []);
+  });
+
+  it("says so rather than writing a file when there is nothing to export", async () => {
+    discard();
+    await vscode.commands.executeCommand("kdb.resultsPanel.clear");
+    clear();
+
+    await vscode.commands.executeCommand("kdb.resultsPanel.export.csv");
+
+    assert.deepStrictEqual(exported(), []);
+    assert.strictEqual(raised("No results to export").length, 1);
+  });
+});

--- a/test/e2e/history.test.ts
+++ b/test/e2e/history.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 1998-2026 KX Systems Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+import * as assert from "node:assert";
+import * as vscode from "vscode";
+
+import { activate, until } from "./utils";
+import { CONNECTION as KDB, kdb, start as startKdb } from "./utils/connection";
+import {
+  CONNECTION as INSIGHTS,
+  insights,
+  start as startInsights,
+} from "./utils/insights";
+import { clear, untilRaised } from "./utils/prompt";
+
+/**
+ * Rerunning and copying an entry of the query history.
+ *
+ * The history itself is a tree, and a tree's contents are not reachable from a
+ * test window, so what these drive are the commands its items run, given the
+ * entry the tree would hand them. Everything past that point is real: the
+ * query goes back to the process it was run on the first time.
+ */
+
+// The entry the tree hands the commands. Only the connection, the query and
+// how it was run are read; the rest is what the tree draws its label from.
+const entry = (
+  connectionName: string,
+  query: string,
+  kdbConnection = true,
+) => ({
+  details: {
+    executorName: "history.q",
+    connectionName,
+    connectionType: kdbConnection ? 1 : 0,
+    query,
+    time: new Date().toISOString(),
+    success: true,
+    language: "q",
+  },
+});
+
+const KDB_QUERY = '"HISTORY_ON_KDB"';
+const INSIGHTS_QUERY = '"HISTORY_ON_INSIGHTS"';
+
+describe("Query history", () => {
+  before(async () => {
+    await activate();
+    await startKdb();
+    await startInsights();
+  });
+
+  beforeEach(() => clear());
+
+  describe("rerunning an entry", () => {
+    it("sends the query back to the kdb+ process it was run on", async () => {
+      kdb.clear();
+      await vscode.commands.executeCommand(
+        "kdb.queryHistory.rerun",
+        entry(KDB, KDB_QUERY),
+      );
+
+      await until(
+        () => kdb.queries().some((request) => request.args?.code === KDB_QUERY),
+        `the query to reach ${KDB} (sent ${kdb
+          .queries()
+          .map((request) => request.args?.code)
+          .join(", ")})`,
+      );
+    });
+
+    it("sends the query back to the Insights connection it was run on", async () => {
+      insights.clear();
+      await vscode.commands.executeCommand(
+        "kdb.queryHistory.rerun",
+        entry(INSIGHTS, INSIGHTS_QUERY, false),
+      );
+
+      await until(
+        () => insights.queries().length > 0,
+        "the query to reach the Insights connection",
+      );
+
+      const request = insights.queries()[0];
+      assert.strictEqual(request.path, "/scratchpadmanager/scratchpad/display");
+      assert.strictEqual(request.body.expression, INSIGHTS_QUERY);
+    });
+  });
+
+  describe("copying an entry", () => {
+    it("puts the query on the clipboard", async () => {
+      const clipboard = await vscode.env.clipboard.readText();
+      try {
+        await vscode.commands.executeCommand(
+          "kdb.queryHistory.copyQuery",
+          entry(KDB, KDB_QUERY),
+        );
+
+        await untilRaised("copied to clipboard");
+        assert.strictEqual(await vscode.env.clipboard.readText(), KDB_QUERY);
+      } finally {
+        await vscode.env.clipboard.writeText(clipboard);
+      }
+    });
+  });
+});

--- a/test/e2e/insights.test.ts
+++ b/test/e2e/insights.test.ts
@@ -30,6 +30,7 @@ import {
   CONSOLE,
   dial,
   ensure,
+  handshake,
   insights,
   instanceAt,
   start,
@@ -51,6 +52,8 @@ const TARGET_FILE = file("target.q");
 const OLD_FILE = file("old.q");
 const OLD_SQL_FILE = file("old.sql");
 const OLDER_FILE = file("older.q");
+const RECENT_FILE = file("recent.q");
+const RECENT_SQL_FILE = file("recent.sql");
 
 const ASSIGNED: [vscode.Uri, vscode.Uri][] = [
   [file("main.q"), Q_FILE],
@@ -65,6 +68,8 @@ const ASSIGNED: [vscode.Uri, vscode.Uri][] = [
   [file("main.q"), OLD_FILE],
   [file("main.sql"), OLD_SQL_FILE],
   [file("main.q"), OLDER_FILE],
+  [file("main.q"), RECENT_FILE],
+  [file("main.sql"), RECENT_SQL_FILE],
 ];
 
 // Written rather than copied: it exists to carry the marker the stand-in fails
@@ -90,9 +95,6 @@ const POPULATE_SQL = "where px > 300";
 const POPULATE_PY = "POPULATE_PY";
 
 const SCRATCHPAD = "/scratchpadmanager/scratchpad/display";
-
-// What connect() asked for, kept before any test clears the recording.
-let handshake: Request[] = [];
 
 // The first request a command sent, once it has arrived.
 async function run(command: string) {
@@ -128,7 +130,6 @@ describe("Executing on an Insights connection", () => {
     fs.writeFileSync(FAILING_FILE.fsPath, `${FakeInsights.FAILS}\n`);
 
     await start();
-    handshake = [...insights.requests];
   });
 
   after(async () => {
@@ -494,7 +495,10 @@ describe("Executing on an Insights connection", () => {
 
       assert.strictEqual(request.body.returnFormat, "text");
 
-      await untilConsoleShows(RESULT, "the result to be printed to the console");
+      await untilConsoleShows(
+        RESULT,
+        "the result to be printed to the console",
+      );
     });
 
     it("asks for structured text for the view", async () => {
@@ -523,6 +527,7 @@ describe("Executing on an Insights connection", () => {
   describe("against other instance versions", () => {
     const OLD = instanceAt(25201, "TESTOLD");
     const OLDER = instanceAt(25202, "TESTOLDER");
+    const RECENT = instanceAt(25204, "TESTRECENT");
 
     // 1.13 with query environments enabled: the endpoints gain a qe/ segment
     // and sql has no kxi/ one yet.
@@ -534,9 +539,16 @@ describe("Executing on an Insights connection", () => {
     const older = new FakeInsights();
     older.version = "1.10.0";
 
-    // Which endpoint each was asked for the meta on, kept before the queries
-    // below clear the recordings.
+    // The oldest instance still supported, which is on the current endpoints
+    // but has no scratchpad log websocket yet.
+    const recent = new FakeInsights();
+    recent.version = "1.17.0";
+
+    // Which endpoint each was asked for the meta on, and how often each was
+    // asked for the api configuration, kept before the queries below clear the
+    // recordings.
     let metas: { [alias: string]: string[] } = {};
+    let configs: { [alias: string]: number } = {};
 
     before(async () => {
       await old.listen(25201);
@@ -547,14 +559,25 @@ describe("Executing on an Insights connection", () => {
       await ensure(OLDER);
       await dial(OLDER.alias, older);
 
+      await recent.listen(25204);
+      await ensure(RECENT);
+      await dial(RECENT.alias, recent);
+
       metas = {
         [OLD.alias]: old.calls("/meta").map((request) => request.path),
         [OLDER.alias]: older.calls("/meta").map((request) => request.path),
+        [RECENT.alias]: recent.calls("/meta").map((request) => request.path),
+      };
+
+      configs = {
+        [OLD.alias]: old.calls("/api/config").length,
+        [OLDER.alias]: older.calls("/api/config").length,
+        [RECENT.alias]: recent.calls("/api/config").length,
       };
     });
 
     after(async () => {
-      for (const alias of [OLD.alias, OLDER.alias]) {
+      for (const alias of [OLD.alias, OLDER.alias, RECENT.alias]) {
         await vscode.commands.executeCommand(
           "kdb.connections.disconnect",
           alias,
@@ -562,6 +585,7 @@ describe("Executing on an Insights connection", () => {
       }
       await old.close();
       await older.close();
+      await recent.close();
     });
 
     async function runOn(target: FakeInsights, uri: vscode.Uri) {
@@ -603,6 +627,45 @@ describe("Executing on an Insights connection", () => {
 
       assert.strictEqual(request.body.returnFormat, undefined);
       assert.strictEqual(request.body.isTableView, false);
+    });
+
+    /**
+     * 1.17 is the oldest instance the extension still connects to, and it is
+     * already on the endpoints the current ones use — the only thing it is
+     * missing is the scratchpad log websocket, which arrived in 1.18.
+     */
+    describe("on 1.17, the oldest instance still supported", () => {
+      it("connects and asks for the meta where it now lives", () => {
+        assert.deepStrictEqual(metas[RECENT.alias], [
+          "/servicegateway/api/v3/meta",
+        ]);
+      });
+
+      it("runs the scratchpad and sql on the current endpoints", async () => {
+        const scratchpad = await runOn(recent, RECENT_FILE);
+        assert.strictEqual(scratchpad.path, SCRATCHPAD);
+
+        const sql = await runOn(recent, RECENT_SQL_FILE);
+        assert.strictEqual(sql.path, "/servicegateway/kxi/sql");
+      });
+
+      it("opens no scratchpad log websocket", () => {
+        // The 1.18 stand-in the rest of the suite runs against did open one,
+        // so this is the gate rather than a socket that never opens at all.
+        assert.ok(insights.upgrades.length > 0, "1.18 opened no log socket");
+        assert.deepStrictEqual(recent.upgrades, []);
+      });
+    });
+
+    /**
+     * The endpoint the query environment prefix is read from only exists from
+     * 1.13. Older instances resolve their endpoints without it, and are never
+     * asked.
+     */
+    it("asks for the api configuration only from 1.13", () => {
+      assert.strictEqual(configs[OLD.alias], 1);
+      assert.strictEqual(configs[RECENT.alias], 1);
+      assert.strictEqual(configs[OLDER.alias], 0);
     });
   });
 });

--- a/test/e2e/language.test.ts
+++ b/test/e2e/language.test.ts
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 1998-2026 KX Systems Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+import * as assert from "node:assert";
+import * as vscode from "vscode";
+
+import {
+  activate,
+  caretAt,
+  completions,
+  file,
+  until,
+  waitForLanguageServer,
+} from "./utils";
+
+/**
+ * The q language features, driven the way the editor drives them. The language
+ * server runs as its own process and nothing here is stubbed, so what these
+ * assert on is what a user gets from Go to Definition, Find References, the
+ * completion list and the rest.
+ */
+
+const LANG = file("lang.q");
+
+const CALC = ".e2e.calc";
+const BLOCK = "LANG_BLOCK_MARKER";
+const SYMBOL = "`:/tmp/e2e/lang/data";
+const LOCAL = "total";
+
+let document: vscode.TextDocument;
+
+/**
+ * Where the nth occurrence of `text` sits, `into` characters in, so the
+ * position is inside the token rather than on its edge. The assertions name
+ * the code they act on; line and column numbers would move with every edit.
+ */
+function inside(text: string, occurrence = 0, into = 2) {
+  const source = document.getText();
+  let offset = -1;
+  for (let found = 0; found <= occurrence; found++) {
+    offset = source.indexOf(text, offset + 1);
+    assert.notStrictEqual(
+      offset,
+      -1,
+      `lang.q has no occurrence ${occurrence} of ${text}`,
+    );
+  }
+  return document.positionAt(offset + Math.min(into, text.length - 1));
+}
+
+// The line the nth occurrence of `text` is on.
+const lineOf = (text: string, occurrence = 0) => inside(text, occurrence).line;
+
+// Every symbol in the document, flattened: a lambda's parameters and locals
+// are nested under it.
+function flatten(symbols: vscode.DocumentSymbol[]): vscode.DocumentSymbol[] {
+  return symbols.flatMap((symbol) => [symbol, ...flatten(symbol.children)]);
+}
+
+const names = (symbols: vscode.DocumentSymbol[]) =>
+  flatten(symbols).map((symbol) => symbol.name);
+
+async function symbols() {
+  return (
+    (await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+      "vscode.executeDocumentSymbolProvider",
+      LANG,
+    )) ?? []
+  );
+}
+
+describe("q language features", () => {
+  before(async () => {
+    await activate();
+    document = await vscode.workspace.openTextDocument(LANG);
+    await vscode.window.showTextDocument(document, { preview: false });
+    await waitForLanguageServer(LANG);
+  });
+
+  after(async () => {
+    await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+  });
+
+  describe("document symbols", () => {
+    it("lists the globals the file defines", async () => {
+      const found = names(await symbols());
+
+      for (const name of [CALC, ".e2e.report", "path"]) {
+        assert.ok(found.includes(name), `${name} is missing from ${found}`);
+      }
+    });
+
+    /**
+     * A symbol literal runs to the end of the token, forward slashes and all.
+     * Were one read as the start of a trailing comment instead, everything
+     * after it on the line would be dropped and the assignment would not be a
+     * definition at all.
+     */
+    it("reads a symbol literal containing forward slashes as one token", async () => {
+      const found = flatten(await symbols()).find(
+        (symbol) => symbol.name === "path",
+      );
+
+      assert.ok(found, "path was not defined");
+      assert.strictEqual(found.range.start.line, lineOf(SYMBOL));
+    });
+
+    it("nests a lambda's parameters and locals under it", async () => {
+      const found = names(await symbols());
+
+      for (const name of ["qty", "px", LOCAL]) {
+        assert.ok(found.includes(name), `${name} is missing from ${found}`);
+      }
+    });
+  });
+
+  describe("navigation", () => {
+    it("goes from a call to the definition", async () => {
+      const definitions = await vscode.commands.executeCommand<
+        vscode.Location[]
+      >("vscode.executeDefinitionProvider", LANG, inside(CALC, 1));
+
+      assert.strictEqual(definitions.length, 1);
+      assert.strictEqual(definitions[0].uri.fsPath, LANG.fsPath);
+      assert.strictEqual(definitions[0].range.start.line, lineOf(CALC, 0));
+    });
+
+    it("finds every reference to a global", async () => {
+      const references = await vscode.commands.executeCommand<
+        vscode.Location[]
+      >("vscode.executeReferenceProvider", LANG, inside(CALC, 0));
+
+      const lines = references.map((reference) => reference.range.start.line);
+
+      // The call inside .e2e.report and the one at the end of the file.
+      for (const occurrence of [1, 2]) {
+        assert.ok(
+          lines.includes(lineOf(CALC, occurrence)),
+          `occurrence ${occurrence} is missing from lines ${lines}`,
+        );
+      }
+    });
+
+    /**
+     * Every place the function is named, the definition included. The entries
+     * carry the callee's own name rather than the enclosing function's, so
+     * what they identify is the call site and not the caller.
+     */
+    it("lists a function's call sites in the call hierarchy", async () => {
+      const prepared = await vscode.commands.executeCommand<
+        vscode.CallHierarchyItem[]
+      >("vscode.prepareCallHierarchy", LANG, inside(CALC, 0));
+
+      assert.ok(prepared?.length, "no call hierarchy item was prepared");
+      assert.strictEqual(prepared[0].name, CALC);
+
+      const incoming = await vscode.commands.executeCommand<
+        vscode.CallHierarchyIncomingCall[]
+      >("vscode.provideIncomingCalls", prepared[0]);
+
+      const lines = incoming.map((call) => call.from.range.start.line);
+
+      // The definition, the call inside .e2e.report, and the one at the end
+      // of the file.
+      assert.deepStrictEqual(lines, [
+        lineOf(CALC, 0),
+        lineOf(CALC, 1),
+        lineOf(CALC, 2),
+      ]);
+    });
+  });
+
+  describe("editing", () => {
+    it("folds a block comment as one range", async () => {
+      const ranges = await vscode.commands.executeCommand<
+        vscode.FoldingRange[]
+      >("vscode.executeFoldingRangeProvider", LANG);
+
+      const marker = lineOf(BLOCK);
+      const found = ranges.find(
+        (range) => range.start <= marker && range.end >= marker,
+      );
+
+      assert.ok(found, `no folding range covers line ${marker} of ${ranges}`);
+      assert.strictEqual(found.kind, vscode.FoldingRangeKind.Comment);
+    });
+
+    // What Expand Selection does with the caret part way through a name.
+    it("expands the selection to the whole name", async () => {
+      const ranges = await vscode.commands.executeCommand<
+        vscode.SelectionRange[]
+      >("vscode.executeSelectionRangeProvider", LANG, [inside(LOCAL, 1)]);
+
+      assert.ok(ranges?.length, "no selection range was offered");
+      assert.strictEqual(document.getText(ranges[0].range), LOCAL);
+    });
+
+    it("completes a namespace member from its prefix", async () => {
+      // Right after the dot that ends the namespace, i.e. ".e2e.|calc".
+      const labels = await completions(LANG, inside(CALC, 2, ".e2e.".length));
+      assert.ok(
+        labels.some((label) => label.includes("calc")),
+        `calc is missing from the completions ${labels}`,
+      );
+    });
+
+    /**
+     * A document that has never been saved has no path on disk, so it only
+     * reaches the language server if untitled documents are synchronised too.
+     */
+    it("completes in a document that has never been saved", async () => {
+      const untitled = await vscode.workspace.openTextDocument({
+        language: "q",
+        content: ".unsaved.value:42;\n.unsaved.v",
+      });
+      await vscode.window.showTextDocument(untitled, { preview: false });
+
+      const position = new vscode.Position(1, 10);
+
+      // The server is told about the document as it opens, so the first
+      // request can arrive before it knows anything about it.
+      let labels: string[] = [];
+      for (let attempt = 0; attempt < 100; attempt++) {
+        labels = await completions(untitled.uri, position);
+        if (labels.some((label) => label.includes("value"))) {
+          return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+
+      assert.fail(`value is missing from the completions ${labels}`);
+    });
+  });
+
+  /**
+   * Toggle Parameter Cache rewrites the document, so this puts it back
+   * afterwards rather than leaving the change for the tests that follow.
+   */
+  describe("the parameter cache", () => {
+    const CACHED = ".axdebug.temp";
+
+    afterEach(async () => {
+      await vscode.commands.executeCommand("workbench.action.files.revert");
+    });
+
+    it("caches a lambda's parameters and takes them back out", async () => {
+      await caretAt(LANG, LOCAL);
+      await vscode.commands.executeCommand("kdb.toggleParameterCache");
+      await until(
+        () => document.getText().includes(CACHED),
+        "the parameters to be cached",
+      );
+
+      const cached = document.getText();
+      assert.ok(
+        cached.includes("`qty`px set'"),
+        `the parameters were not set:\n${cached}`,
+      );
+
+      await caretAt(LANG, LOCAL);
+      await vscode.commands.executeCommand("kdb.toggleParameterCache");
+      await until(
+        () => !document.getText().includes(CACHED),
+        "the cache to be removed again",
+      );
+    });
+  });
+});

--- a/test/e2e/meta.test.ts
+++ b/test/e2e/meta.test.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 1998-2026 KX Systems Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+import * as assert from "node:assert";
+import * as vscode from "vscode";
+
+import { activate, until } from "./utils";
+import { CONNECTION as KDB, start as startKdb } from "./utils/connection";
+import { meta } from "./utils/fixtures";
+import { CONNECTION, start } from "./utils/insights";
+import { clear, raised, untilRaised } from "./utils/prompt";
+
+/**
+ * What the instance said about itself, opened from the tree. Each meta object
+ * is a node under the connection's meta node, and the command those nodes run
+ * is given the connection and the object's name — which is all this needs to
+ * stand in for the click.
+ */
+
+const node = (label: string, connLabel = CONNECTION) => ({ connLabel, label });
+
+// The document the command opened, once it is in front. The content provider
+// serves one document at a time, so this waits for the editor rather than
+// looking the document up by name.
+async function opened() {
+  await until(
+    () => vscode.window.activeTextEditor?.document.uri.scheme === "meta",
+    "a meta document to be opened",
+  );
+  return vscode.window.activeTextEditor!.document;
+}
+
+async function open(label: string, connLabel?: string) {
+  await vscode.commands.executeCommand(
+    "kdb.connections.open.meta",
+    node(label, connLabel),
+  );
+}
+
+describe("The meta objects of an Insights connection", () => {
+  before(async () => {
+    await activate();
+    await start();
+  });
+
+  beforeEach(async () => {
+    clear();
+    await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+  });
+
+  after(async () => {
+    await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+  });
+
+  it("names the document after the connection and the object", async () => {
+    await open("schema");
+    const document = await opened();
+
+    assert.strictEqual(document.uri.scheme, "meta");
+    assert.strictEqual(document.uri.path, `${CONNECTION} - schema.json`);
+  });
+
+  it("shows each object of the meta the instance answered with", async () => {
+    for (const [label, payload] of [
+      ["schema", meta.payload.schema],
+      ["api", meta.payload.api],
+      ["dap", meta.payload.dap],
+      ["rc", meta.payload.rc],
+      ["agg", meta.payload.agg],
+    ] as [string, unknown][]) {
+      await open(label);
+      const document = await opened();
+
+      assert.deepStrictEqual(
+        JSON.parse(document.getText()),
+        payload,
+        `the ${label} object`,
+      );
+      await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+    }
+  });
+
+  it("shows the whole payload for the meta node itself", async () => {
+    await open("meta");
+    const document = await opened();
+
+    assert.deepStrictEqual(JSON.parse(document.getText()), meta.payload);
+  });
+
+  it("formats what it shows rather than serving it as one line", async () => {
+    await open("dap");
+    const document = await opened();
+
+    assert.ok(
+      document.lineCount > 1,
+      `the document is a single line:\n${document.getText()}`,
+    );
+  });
+
+  it("refuses an object the meta has no such type for", async () => {
+    await open("nosuchobject");
+
+    await untilRaised("not valid");
+    assert.strictEqual(
+      vscode.window.activeTextEditor,
+      undefined,
+      "a document was opened for an object that does not exist",
+    );
+  });
+
+  it("refuses a connection that is not an Insights one", async () => {
+    await startKdb();
+    await open("schema", KDB);
+
+    await untilRaised("not an Insights connection");
+    assert.strictEqual(
+      raised("not an Insights connection")[0].kind,
+      "error",
+      "the refusal was not reported as an error",
+    );
+    assert.strictEqual(vscode.window.activeTextEditor, undefined);
+  });
+});

--- a/test/e2e/objects.test.ts
+++ b/test/e2e/objects.test.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 1998-2026 KX Systems Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+import * as assert from "node:assert";
+import * as fs from "node:fs";
+import * as vscode from "vscode";
+
+import { activate, completions, file, focus, until } from "./utils";
+import { CONNECTION, kdb, start } from "./utils/connection";
+import { MemoryItem } from "./utils/qserver";
+
+/**
+ * What the process reports having in memory, as the editor sees it.
+ *
+ * The listing is asked for over IPC on connect and after every query, and each
+ * item becomes a completion for the connected process. The tree draws the same
+ * listing under Tables, Functions and the rest, but a tree's contents are not
+ * reachable from a test window — the extension exposes no API for them — so
+ * how items are filed by category is covered in test/suite instead.
+ */
+
+const FIXTURE = file("objects.q");
+
+// The namespaces and the items in them, in the shape listMem.q reports: an
+// item's fname carries its namespace, a namespace's own row is marked isNs.
+let next = 0;
+
+function item(
+  name: string,
+  typeNum: number,
+  namespace = ".",
+  isNs = false,
+): MemoryItem {
+  return {
+    id: next++,
+    pid: 0,
+    name,
+    fname: namespace === "." ? name : `${namespace}.${name}`,
+    typeNum,
+    namespace,
+    context: namespace === "." ? "" : namespace,
+    isNs,
+  };
+}
+
+const namespace = (name: string) => ({
+  ...item(name, 99, ".", true),
+  fname: name,
+});
+
+const MEMORY: MemoryItem[] = [
+  namespace("."),
+  namespace(".e2e"),
+  item("trade", 98),
+  item("pricer", 100),
+  item("px", -9),
+  item("syms", 11),
+  item("helper", 100, ".e2e"),
+  item("rates", 98, ".e2e"),
+  // The namespace the extension injects into the process to talk to it. Its
+  // own API must never be offered back to the user as their code.
+  item("getManifest", 100, ".vscode"),
+];
+
+describe("What the connected process has in memory", () => {
+  let offered: string[] = [];
+
+  before(async () => {
+    await activate();
+    await start();
+
+    kdb.serverObjects = MEMORY;
+
+    /**
+     * The listing is read on connect, and only the process connected last is
+     * the one completions are offered for. Suites that ran earlier will have
+     * connected something else since, so this connects again — which both
+     * makes the stand-in current and has it read the listing set above.
+     */
+    kdb.clear();
+    await vscode.commands.executeCommand(
+      "kdb.connections.disconnect",
+      CONNECTION,
+    );
+    await vscode.commands.executeCommand(
+      "kdb.connections.connect.via.dialog",
+      CONNECTION,
+    );
+    await until(
+      () => kdb.requests.some((request) => request.fn === ".vscode.listMem"),
+      "the memory listing to be asked for",
+    );
+
+    fs.writeFileSync(FIXTURE.fsPath, "/ objects.q\n");
+    await focus(FIXTURE);
+
+    // The listing is answered after the connection reports itself ready, so
+    // what it produced has to be waited for rather than read once.
+    for (let attempt = 0; attempt < 100; attempt++) {
+      offered = await completions(FIXTURE);
+      if (offered.includes("trade")) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    assert.ok(
+      offered.includes("trade"),
+      `the memory listing was never offered as completions: ${offered}`,
+    );
+  });
+
+  after(async () => {
+    kdb.serverObjects = [];
+    fs.rmSync(FIXTURE.fsPath, { force: true });
+    await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+  });
+
+  it("offers every item the process reported", () => {
+    for (const name of ["trade", "pricer", "px", "syms"]) {
+      assert.ok(offered.includes(name), `${name} is missing from ${offered}`);
+    }
+  });
+
+  it("offers an item in a namespace by its full name", () => {
+    for (const name of [".e2e.helper", ".e2e.rates"]) {
+      assert.ok(offered.includes(name), `${name} is missing from ${offered}`);
+    }
+    assert.ok(
+      !offered.includes("helper"),
+      "a namespaced item was offered by its bare name",
+    );
+  });
+
+  it("offers no namespace as an item of its own", () => {
+    for (const name of [".", ".e2e"]) {
+      assert.ok(!offered.includes(name), `the namespace ${name} was offered`);
+    }
+  });
+
+  it("offers nothing out of the namespace the extension injected", () => {
+    const injected = offered.filter((name) => name.startsWith(".vscode"));
+
+    assert.deepStrictEqual(injected, []);
+  });
+});

--- a/test/e2e/repl.test.ts
+++ b/test/e2e/repl.test.ts
@@ -24,6 +24,7 @@ import {
   lastLineOf,
   mark,
   outputs,
+  reveal,
   runOnRepl as run,
   selectionOf,
   since,
@@ -94,6 +95,13 @@ describe("Executing on the REPL", () => {
       fs.copyFileSync(source.fsPath, workbook.fsPath);
     }
     await waitForLanguageServer(Q_FILE);
+
+    // An unassigned file runs on whichever KX terminal was focused last, so
+    // whatever a suite before this one left connected, the REPL has to be the
+    // one in front before any of these run.
+    await vscode.commands.executeCommand("kdb.repl.start");
+    await until(() => !!terminal(REPL), "the REPL terminal to open");
+    await reveal(REPL);
   });
 
   after(async () => {

--- a/test/e2e/scratchpad.test.ts
+++ b/test/e2e/scratchpad.test.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 1998-2026 KX Systems Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+import * as assert from "node:assert";
+import * as fs from "node:fs";
+import * as vscode from "vscode";
+
+import { activate, file, focus, settle, until } from "./utils";
+import { CONNECTION as KDB, start as startKdb } from "./utils/connection";
+import { ASSEMBLY, TIER } from "./utils/fixtures";
+import {
+  CONNECTION,
+  dial,
+  ensure,
+  insights,
+  instanceAt,
+  start,
+} from "./utils/insights";
+import { FakeInsights } from "./utils/insightsServer";
+import { answer, clear, untilRaised } from "./utils/prompt";
+
+/**
+ * Resetting a scratchpad, and the execution timeout every Insights request
+ * carries. Both are settings and confirmations rather than code, so what they
+ * are asserted on is the request that leaves — or the absence of one.
+ */
+
+const RESET = "/scratchpadmanager/reset";
+const CONFIRMATION = "Reset Scratchpad?";
+
+// Copies of main.q under the paths kdb.connectionMap and kdb.timeoutMap assign
+// to this suite.
+const TIMED_FILE = file("timeout.q");
+const TIMED_TARGET = file("timeout.target.q");
+const ASSIGNED = [TIMED_FILE, TIMED_TARGET];
+
+// What kdb.timeoutMap gives timeout.q in the workspace settings, and what
+// kdb.defaultTimeout leaves everything else on.
+const OVERRIDDEN = 5;
+const DEFAULT = 30;
+
+async function reset(connLabel = CONNECTION) {
+  insights.clear();
+  await vscode.commands.executeCommand("kdb.scratchpad.reset", {
+    label: connLabel,
+  });
+}
+
+// The first request a run sent, once it has arrived.
+async function run(uri: vscode.Uri) {
+  insights.clear();
+  await focus(uri);
+  await vscode.commands.executeCommand("kdb.execute.fileQuery");
+  await until(() => insights.queries().length > 0, `a request for ${uri.path}`);
+  return insights.queries()[0];
+}
+
+describe("The Insights scratchpad", () => {
+  before(async () => {
+    await activate();
+    for (const assigned of ASSIGNED) {
+      fs.copyFileSync(file("main.q").fsPath, assigned.fsPath);
+    }
+    await start();
+  });
+
+  beforeEach(() => clear());
+
+  after(async () => {
+    for (const assigned of ASSIGNED) {
+      fs.rmSync(assigned.fsPath, { force: true });
+    }
+    await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+  });
+
+  describe("resetting it", () => {
+    it("asks before it resets, and resets when told to", async () => {
+      answer(CONFIRMATION, "Yes");
+      await reset();
+
+      await until(
+        () => insights.calls(RESET).length > 0,
+        "the reset to be sent",
+      );
+      assert.strictEqual(insights.calls(RESET)[0].method, "POST");
+    });
+
+    it("sends nothing when the reset is declined", async () => {
+      answer(CONFIRMATION, "No");
+      await reset();
+
+      await settle();
+
+      assert.deepStrictEqual(insights.calls(RESET), []);
+    });
+
+    it("refuses a connection that is not an Insights one", async () => {
+      await startKdb();
+      await reset(KDB);
+
+      await untilRaised("connect to an Insights connection");
+      assert.deepStrictEqual(insights.calls(RESET), []);
+    });
+
+    /**
+     * The endpoint exists further back than the confirmation does, but the
+     * command asks for 1.13 before it offers to reset at all.
+     */
+    describe("against an instance older than 1.13", () => {
+      const OLD = instanceAt(25203, "TESTRESET");
+      const old = new FakeInsights();
+      old.version = "1.12.0";
+
+      before(async () => {
+        await old.listen(25203);
+        await ensure(OLD);
+        await dial(OLD.alias, old);
+      });
+
+      after(async () => {
+        await vscode.commands.executeCommand(
+          "kdb.connections.disconnect",
+          OLD.alias,
+        );
+        await old.close();
+      });
+
+      it("says so rather than offering to reset", async () => {
+        old.clear();
+        await vscode.commands.executeCommand("kdb.scratchpad.reset", {
+          label: OLD.alias,
+        });
+
+        await untilRaised("version 1.13 or higher");
+        assert.deepStrictEqual(old.calls(RESET), []);
+      });
+    });
+  });
+
+  /**
+   * Every Insights request carries the execution timeout the file resolves to,
+   * as a header for the scratchpad and inside the body for a DAP, which reads
+   * it in milliseconds.
+   */
+  describe("the execution timeout", () => {
+    it("sends the workspace default with a file that has no timeout of its own", async () => {
+      const request = await run(TIMED_TARGET);
+
+      assert.strictEqual(request.headers.timeout, undefined);
+      assert.strictEqual(request.body.opts?.timeout, DEFAULT * 1000);
+    });
+
+    it("sends the timeout the file was given instead", async () => {
+      const request = await run(TIMED_FILE);
+
+      assert.strictEqual(request.headers.timeout, String(OVERRIDDEN));
+    });
+
+    it("targets the assembly the file is assigned to", async () => {
+      const request = await run(TIMED_TARGET);
+
+      assert.deepStrictEqual(request.body.scope, {
+        affinity: "soft",
+        assembly: ASSEMBLY,
+        tier: TIER,
+      });
+    });
+  });
+});

--- a/test/e2e/utils/index.ts
+++ b/test/e2e/utils/index.ts
@@ -101,6 +101,34 @@ export function outputs(notebook: vscode.NotebookDocument) {
     );
 }
 
+/**
+ * What the completion list at a position offers, as plain strings. The
+ * language server and the connected process both contribute to it, so this is
+ * the merged list a user is shown.
+ */
+export async function completions(
+  uri: vscode.Uri,
+  position = new vscode.Position(0, 0),
+) {
+  const list = await vscode.commands.executeCommand<vscode.CompletionList>(
+    "vscode.executeCompletionItemProvider",
+    uri,
+    position,
+  );
+  return (list?.items ?? []).map((item) =>
+    typeof item.label === "string" ? item.label : item.label.label,
+  );
+}
+
+/**
+ * Long enough for something that should not happen to have happened.
+ *
+ * A test proving a negative — nothing was sent, nothing connected — has
+ * nothing to wait for, so it waits for the command to have been able to do it
+ * before deciding it did not.
+ */
+export const settle = () => new Promise((resolve) => setTimeout(resolve, 250));
+
 // Generous enough for a loaded CI runner; it only costs that long when
 // something is actually wrong.
 export async function until(condition: () => boolean, what: string) {

--- a/test/e2e/utils/insights.ts
+++ b/test/e2e/utils/insights.ts
@@ -16,7 +16,7 @@ import * as https from "node:https";
 import * as vscode from "vscode";
 
 import { until } from "./index";
-import { FakeInsights } from "./insightsServer";
+import { FakeInsights, Request } from "./insightsServer";
 
 // What the extension is told about an Insights instance, i.e. the arguments
 // kdb.connections.add.insights takes.
@@ -50,6 +50,14 @@ export const CONSOLE = `KX ${INSIGHTS.alias}`;
 // ext.kdbConnectionAliasList until the tree renders again, and validateServerAlias
 // rejects it in the meantime.
 export const insights = new FakeInsights();
+
+/**
+ * Everything connecting asked for, kept as it happens. Whichever suite runs
+ * first is the one that connects, and every suite after it clears the
+ * recording as it goes, so the handshake has to be held on to here rather than
+ * read back later.
+ */
+export const handshake: Request[] = [];
 
 const added: string[] = [];
 let started = false;
@@ -161,6 +169,8 @@ export async function start() {
   await insights.listen(PORT);
   await ensure(INSIGHTS);
   await dial(CONNECTION, insights);
+
+  handshake.push(...insights.requests);
 }
 
 // Torn down once, after every suite in the window has run.

--- a/test/e2e/utils/prompt.ts
+++ b/test/e2e/utils/prompt.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 1998-2026 KX Systems Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+/* eslint @typescript-eslint/no-explicit-any: 0 */
+
+import * as vscode from "vscode";
+
+import { until } from "./index";
+
+/**
+ * Stands in for the person a notification is addressed to.
+ *
+ * A notification's buttons are drawn by the workbench and there is no API that
+ * presses one, so a command that asks before it acts cannot be driven to
+ * either answer. This takes the same place the browser stand-in does in
+ * utils/insights.ts: it replaces the part outside the extension — the reader —
+ * and leaves the extension itself alone. Every notification is recorded, and
+ * one is only answered when a test has said what to answer it with; anything
+ * else is passed to the workbench and shown as usual.
+ */
+
+export interface Notification {
+  kind: "info" | "warning" | "error";
+  message: string;
+  buttons: string[];
+}
+
+// Every notification raised since the last clear(), in order.
+export const notifications: Notification[] = [];
+
+interface Answer {
+  match: string;
+  button: string;
+}
+
+const answers: Answer[] = [];
+let installed = false;
+
+const KINDS = {
+  info: "showInformationMessage",
+  warning: "showWarningMessage",
+  error: "showErrorMessage",
+} as const;
+
+function install() {
+  if (installed) {
+    return;
+  }
+  installed = true;
+
+  for (const [kind, method] of Object.entries(KINDS) as [
+    Notification["kind"],
+    (typeof KINDS)[keyof typeof KINDS],
+  ][]) {
+    const real = vscode.window[method] as any;
+
+    Object.defineProperty(vscode.window, method, {
+      configurable: true,
+      writable: true,
+      value: (message: string, ...rest: any[]) => {
+        // The options object, when there is one, comes before the buttons.
+        const buttons = rest.filter(
+          (item): item is string => typeof item === "string",
+        );
+        notifications.push({ kind, message, buttons });
+
+        const index = answers.findIndex((answer) =>
+          message.includes(answer.match),
+        );
+        if (index === -1) {
+          return real.call(vscode.window, message, ...rest);
+        }
+
+        return Promise.resolve(answers.splice(index, 1)[0].button);
+      },
+    });
+  }
+}
+
+/**
+ * Presses `button` on the next notification whose message contains `match`.
+ * Queued rather than applied, because the notification is raised part way
+ * through the command being tested.
+ */
+export function answer(match: string, button: string) {
+  install();
+  answers.push({ match, button });
+}
+
+export function clear() {
+  install();
+  notifications.length = 0;
+  answers.length = 0;
+}
+
+// The notifications raised so far, of any kind, whose message contains `text`.
+export const raised = (text: string) =>
+  notifications.filter((notification) => notification.message.includes(text));
+
+/**
+ * Waits for a notification carrying `text`. A command resolves before the
+ * notifications it raises on the way have all been recorded, so what was said
+ * has to be waited for rather than read once.
+ */
+export const untilRaised = (text: string) =>
+  until(() => raised(text).length > 0, `a notification saying "${text}"`);

--- a/test/e2e/utils/qserver.ts
+++ b/test/e2e/utils/qserver.ts
@@ -25,6 +25,24 @@ export interface Request {
   args?: { code?: string; ctx?: string; returnFormat?: string };
 }
 
+/**
+ * A row of what listMem.q answers with, i.e. one item in the process memory.
+ * `typeNum` is the q type of the value, which is what decides the category the
+ * item is filed under: 98 a table, 99 a dictionary or a keyed table, 100 a
+ * lambda, 104 a projection, 105 a composition, and anything below 98 a plain
+ * variable.
+ */
+export interface MemoryItem {
+  id: number;
+  pid: number;
+  name: string;
+  fname: string;
+  typeNum: number;
+  namespace: string;
+  context: string;
+  isNs: boolean;
+}
+
 // What a failing query reports back.
 export const FAILURE = "fake q failure";
 
@@ -59,6 +77,17 @@ export class FakeQ {
   // the evaluate lambda with every request, the way a plain kdb+ process is
   // driven.
   manifest = true;
+
+  // What the process reports having in memory, and which of those names are
+  // views. Both are empty until a test says otherwise, which is what every
+  // other suite wants: an empty listing leaves the tree with nothing to draw.
+  serverObjects: MemoryItem[] = [];
+  views: string[] = [];
+
+  // What a query answers with. A suite that renders the result rather than
+  // asserting on the request replaces it with something worth rendering — the
+  // structured text a real process answers a results view query with.
+  data: unknown = "OK";
 
   // Any query carrying this comes back as a q error instead of a result.
   static readonly FAILS = "FAIL_QUERY";
@@ -174,9 +203,21 @@ export class FakeQ {
     // Housekeeping calls carry no code: the manifest handshake, the globals
     // poll and the reserved words poll. Which of them arrives depends on
     // whether the .vscode namespace is in use — the lambda forms come through
-    // here too — and an empty list satisfies all but the manifest.
+    // here too — and an empty list satisfies all but the ones answered here.
     if (args?.code === undefined) {
-      return fn === ".vscode.getManifest" ? { version: "fake" } : [];
+      switch (fn) {
+        case ".vscode.getManifest":
+          return { version: "fake" };
+        // loadServerObjects() evals what comes back rather than parsing it, so
+        // the memory listing goes over the wire as a literal and not as a
+        // value.
+        case ".vscode.listMem":
+          return this.serverObjects;
+        case ".vscode.getViews":
+          return this.views;
+        default:
+          return [];
+      }
     }
 
     if (args.code.includes(FakeQ.FAILS)) {
@@ -185,6 +226,6 @@ export class FakeQ {
 
     // What LocalConnection.executeQuery expects: no error, and data it can
     // JSON.parse.
-    return { error: false, data: JSON.stringify("OK") };
+    return { error: false, data: JSON.stringify(this.data) };
   }
 }

--- a/test/e2e/workspace/.vscode/settings.json
+++ b/test/e2e/workspace/.vscode/settings.json
@@ -11,6 +11,8 @@
     "local.kdb.py": "TESTLOCAL",
     "local.kxnb": "TESTLOCAL",
     "plain.q": "TESTPLAIN",
+    "csv.q": "TESTLOCAL",
+    "offer.q": "TESTOFFER",
     "error.kxnb": "TESTLOCAL",
     "pinned.q": "REPL",
     "insights.q": "TESTINSIGHTS",
@@ -24,11 +26,23 @@
     "insights.error.q": "TESTINSIGHTS",
     "target.q": "TESTINSIGHTS",
     "populate.kxnb": "TESTINSIGHTS",
+    "timeout.q": "TESTINSIGHTS",
+    "timeout.target.q": "TESTINSIGHTS",
+    "recent.q": "TESTRECENT",
+    "recent.sql": "TESTRECENT",
     "old.q": "TESTOLD",
     "old.sql": "TESTOLD",
     "older.q": "TESTOLDER"
   },
   "kdb.targetMap": {
-    "target.q": "e2e-assembly tp"
-  }
+    "target.q": "e2e-assembly tp",
+    "timeout.target.q": "e2e-assembly tp"
+  },
+  "kdb.timeoutMap": {
+    "timeout.q": 5
+  },
+  "files.simpleDialog.enable": true,
+  "explorer.confirmDelete": false,
+  "explorer.confirmDragAndDrop": false,
+  "explorer.confirmPasteNative": false
 }

--- a/test/e2e/workspace/lang.q
+++ b/test/e2e/workspace/lang.q
@@ -1,0 +1,25 @@
+/ lang.q — the fixture the language server tests drive. Nothing here is
+/ incidental: every construct is what one of them asserts on, so changing it
+/ changes what they mean.
+
+/
+  A block comment. It folds as one range, from the slash on its own line above
+  to the backslash on its own line below.
+  LANG_BLOCK_MARKER
+\
+
+/ A symbol literal carrying forward slashes. If the lexer stopped at the first
+/ one, the rest of the file would be read as something else and none of the
+/ definitions below would be found.
+path:`:/tmp/e2e/lang/data
+
+.e2e.calc:{[qty;px]
+  total:qty*px;
+  total
+  }
+
+.e2e.report:{[]
+  .e2e.calc[10;20.5]
+  }
+
+.e2e.calc[2;3.5]

--- a/test/suite/classes/localConnection.test.ts
+++ b/test/suite/classes/localConnection.test.ts
@@ -81,4 +81,38 @@ describe("LocalConnection", () => {
     const conn = localConn.getConnection();
     assert.strictEqual(conn, "fakeConnection");
   });
+  describe("loadServerObjects", () => {
+    /**
+     * What a process answers the memory listing with, in the shape listMem.q
+     * reports it: a namespace has a row of its own, marked isNs.
+     */
+    const listing = [
+      { name: ".q", fname: ".q", typeNum: 99, namespace: ".", isNs: true },
+      { name: ".s", fname: ".s", typeNum: 99, namespace: ".", isNs: true },
+      { name: ".e2e", fname: ".e2e", typeNum: 99, namespace: ".", isNs: true },
+      {
+        name: "trade",
+        fname: "trade",
+        typeNum: 98,
+        namespace: ".",
+        isNs: false,
+      },
+    ];
+
+    it("should leave out the namespaces a process keeps to itself", async () => {
+      localConn["connection"] = <any>{};
+      // The process has the .vscode namespace loaded, so the listing is asked
+      // for by name rather than by sending listMem.q over.
+      localConn.useAPI = true;
+      sinon.stub(localConn, "executeQueryRaw").resolves(listing);
+
+      const result = await localConn.loadServerObjects();
+
+      assert.deepStrictEqual(
+        result.map((object) => object.name),
+        [".e2e", "trade"],
+        "an internal namespace was listed",
+      );
+    });
+  });
 });

--- a/test/suite/services/kdbTree/kdbTreeService.test.ts
+++ b/test/suite/services/kdbTree/kdbTreeService.test.ts
@@ -309,4 +309,157 @@ describe("kdbTreeService", () => {
       assert.strictEqual(result[0], "vw1", "Should return the first view");
     });
   });
+  /**
+   * The listing a process answers with, filed the way the tree draws it. The
+   * fixture is the shape listMem.q reports (see test/q/tests/listMem.quke): an
+   * item's fname carries its namespace, and a namespace has a row of its own
+   * marked isNs.
+   */
+  describe("filing a memory listing by category", () => {
+    let next = 0;
+
+    const item = (
+      name: string,
+      typeNum: number,
+      namespace = ".",
+      isNs = false,
+    ): ServerObject => ({
+      id: next++,
+      pid: 0,
+      name,
+      fname: namespace === "." ? name : `${namespace}.${name}`,
+      typeNum,
+      namespace,
+      context: {},
+      isNs,
+    });
+
+    const MEMORY: ServerObject[] = [
+      { ...item(".", 99, ".", true), fname: "." },
+      { ...item(".e2e", 99, ".", true), fname: ".e2e" },
+      item("trade", 98),
+      item("settings", 99),
+      item("pricer", 100),
+      item("applyPx", 104),
+      item("pipeline", 105),
+      item("px", -9),
+      item("syms", 11),
+      item("midView", -7),
+      item("helper", 100, ".e2e"),
+      item("rates", 98, ".e2e"),
+    ];
+
+    const named = (objects: ServerObject[]) =>
+      objects.map((object) => object.fname);
+
+    beforeEach(() => {
+      sinon.stub(localConn, "loadServerObjects").resolves(MEMORY);
+      sinon.stub(KdbTreeService, "loadViews").resolves(["midView"]);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("should list the namespaces a listing carries", async () => {
+      const result = await KdbTreeService.loadNamespaces(localConn);
+
+      assert.deepStrictEqual(named(result), [".", ".e2e"]);
+    });
+
+    it("should file a table under Tables", async () => {
+      const result = await KdbTreeService.loadTables(localConn, ".");
+
+      assert.ok(
+        named(result).includes("trade"),
+        `trade is missing from ${named(result)}`,
+      );
+    });
+
+    it("should file a lambda, a projection and a composition under Functions", async () => {
+      const result = await KdbTreeService.loadFunctions(localConn, ".");
+
+      assert.deepStrictEqual(named(result), ["applyPx", "pipeline", "pricer"]);
+    });
+
+    it("should file a plain value under Variables", async () => {
+      const result = await KdbTreeService.loadVariables(localConn, ".");
+
+      assert.deepStrictEqual(named(result), ["px", "syms"]);
+    });
+
+    it("should leave a view out of the variables", async () => {
+      const result = await KdbTreeService.loadVariables(localConn, ".");
+
+      assert.ok(
+        !named(result).includes("midView"),
+        "a view was filed as a variable",
+      );
+    });
+
+    it("should file only what is in the namespace asked for", async () => {
+      assert.deepStrictEqual(
+        named(await KdbTreeService.loadFunctions(localConn, ".e2e")),
+        [".e2e.helper"],
+      );
+      assert.deepStrictEqual(
+        named(await KdbTreeService.loadTables(localConn, ".e2e")),
+        [".e2e.rates"],
+      );
+    });
+
+    it("should file a namespace itself under no category at all", async () => {
+      for (const category of [
+        KdbTreeService.loadDictionaries,
+        KdbTreeService.loadFunctions,
+        KdbTreeService.loadTables,
+        KdbTreeService.loadVariables,
+      ]) {
+        const result = await category(localConn, ".");
+        assert.ok(
+          !named(result).includes(".e2e"),
+          `the namespace .e2e was filed by ${category.name}`,
+        );
+      }
+    });
+
+    /**
+     * A dictionary and a keyed table are both type 99, and the listing carries
+     * nothing else to tell them apart, so every dictionary is drawn under
+     * Tables as well and every keyed table under Dictionaries. Separating them
+     * needs listMem.q to report whether a 99 is keyed; until it does, this is
+     * what the tree shows.
+     */
+    it.skip("should file a dictionary under Dictionaries alone", async () => {
+      assert.deepStrictEqual(
+        named(await KdbTreeService.loadDictionaries(localConn, ".")),
+        ["settings"],
+      );
+      assert.ok(
+        !named(await KdbTreeService.loadTables(localConn, ".")).includes(
+          "settings",
+        ),
+        "a dictionary was filed as a table",
+      );
+    });
+
+    /**
+     * Namespaces are listed only one level down from the root, so an item in a
+     * nested namespace has no node to sit under — see the commented out
+     * loadNestedNamespaces in kdbTreeProvider.
+     */
+    it.skip("should list a nested namespace", async () => {
+      sinon.restore();
+      sinon
+        .stub(localConn, "loadServerObjects")
+        .resolves([...MEMORY, { ...item(".inner", 99, ".e2e", true) }]);
+
+      assert.ok(
+        named(await KdbTreeService.loadNamespaces(localConn)).includes(
+          ".e2e.inner",
+        ),
+        "a nested namespace was not listed",
+      );
+    });
+  });
 });


### PR DESCRIPTION
### Changes introduced by this PR

- 7 new e2e suites: language server, meta, scratchpad reset/timeouts, CSV export, connect prompt, query history, memory listing. 141 → 185 tests.
- New `utils/prompt.ts` stand-in so notification buttons can be answered; `FakeQ` can now return a memory listing and a real query result.
- Fix: projections and compositions (types 104/105) appeared under no tree category; `.s` no longer listed.
- New `docs/developer/end-to-end-coverage.md` — what the suite covers and what it can't reach.
